### PR TITLE
[analyze revenue] adding a check on commission increase

### DIFF
--- a/evaluate-revenue-changes.bash
+++ b/evaluate-revenue-changes.bash
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 SAM_EPOCH=652
+PAST_EPOCH=$((SAM_EPOCH - 1))
 
-# GCP_PATH="gs://marinade-validator-bonds-mainnet/$SAM_EPOCH/validators.json"
-# SNAPSHOT_VALIDATORS="${SAM_EPOCH}_validators.json"
+GCP_PATH="gs://marinade-validator-bonds-mainnet/"
+SNAPSHOT_VALIDATORS="${SAM_EPOCH}_validators.json"
+gcloud storage cp "${GCP_PATH}/${SAM_EPOCH}/validators.json" "${SNAPSHOT_VALIDATORS}"
 
-# TMP SETUP TO HELP SHOWCASE INTEGRATION
-GCP_PATH="gs://marinade-validator-bonds-mainnet/650/validators.json"
-SNAPSHOT_VALIDATORS="650_validators.json"
+SNAPSHOT_PAST_VALIDATORS="${PAST_EPOCH}_validators.json"
+gcloud storage cp "${GCP_PATH}/${PAST_EPOCH}/validators.json" "${SNAPSHOT_PAST_VALIDATORS}"
 
-gcloud storage cp "gs://marinade-validator-bonds-mainnet/650/validators.json" "$SNAPSHOT_VALIDATORS"
 
 # TODO: handle cases where the scoring is N/A for that specific epoch by iterating back in time epoch by epoch
 SAM_RESPONSE=$(curl -sfLS "https://scoring.marinade.finance/api/v1/scores/sam?epoch=$SAM_EPOCH")
@@ -42,4 +42,5 @@ pnpm run cli -- analyze-revenues \
     --cache-dir-path "$SAM_INPUTS_DIR" \
     --sam-results-fixture-file-path "$SAM_OUTPUTS_DIR/results.json" \
     --snapshot-validators-file-path "$SNAPSHOT_VALIDATORS" \
+    ${SNAPSHOT_PAST_VALIDATORS:+"--snapshot-past-validators-file-path $SNAPSHOT_PAST_VALIDATORS"} \
     --results-file-path evaluation.json | tee out.log

--- a/src/commands/analyze-revenue.cmd.ts
+++ b/src/commands/analyze-revenue.cmd.ts
@@ -1,7 +1,8 @@
 import { Command, CommandRunner, Option } from 'nest-commander'
 import { Logger } from '@nestjs/common'
-import { AuctionResult, AuctionValidator, DsSamSDK, InputsSource, SourceDataOverrides } from '@marinade.finance/ds-sam-sdk'
+import { AuctionResult, AuctionValidator, DsSamSDK, InputsSource, Rewards, SourceDataOverrides } from '@marinade.finance/ds-sam-sdk'
 import fs from 'fs'
+import assert from 'assert'
 
 const COMMAND_NAME = 'analyze-revenues'
 
@@ -9,6 +10,7 @@ type AnalyzeRevenuesCommandOptions = {
   inputsCacheDirPath: string
   samResultsFixtureFilePath: string
   snapshotValidatorsFilePath: string
+  snapshotPastValidatorsFilePath?: string
   resultsFilePath?: string
 }
 
@@ -30,6 +32,22 @@ export type SnapshotValidatorsCollection = {
   validator_metas: SnapshotValidatorMeta[]
 }
 
+type ChangeCommissionsMap = Map<string, ChangeCommission>
+
+type ChangeCommission = {
+  inflationBefore: number,
+  inflationAfter: number,
+  mevBefore: number | null,
+  mevAfter: number | null,
+}
+
+const DEFAULT_CHANGE_COMMISSION: ChangeCommission = {
+  inflationBefore: 0,
+  inflationAfter: 0,
+  mevBefore: 0,
+  mevAfter: 0,
+}
+
 export type RevenueExpectationCollection = {
   epoch: number
   slot: number
@@ -40,11 +58,14 @@ export type RevenueExpectation = {
   voteAccount: string
   expectedInflationCommission: number
   actualInflationCommission: number
+  pastInflationCommission: number
   expectedMevCommission: number | null
   actualMevCommission: number | null
+  pastMevCommission: number | null
   expectedNonBidPmpe: number
   actualNonBidPmpe: number
   expectedSamPmpe: number
+  nonBidCommissionIncreasePmpe: number
   maxSamStake: number | null
   samStakeShare: number
   lossPerStake: number
@@ -98,17 +119,42 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
     this.logger.log(`Running "${COMMAND_NAME}" command...`, { ...config })
 
     const snapshotValidatorsCollection = loadSnapshotValidatorsCollection(options.snapshotValidatorsFilePath)
+
+    let pastSnapshotValidatorsCollection: null | SnapshotValidatorsCollection = null
+    if (options.snapshotPastValidatorsFilePath) {
+      pastSnapshotValidatorsCollection = loadSnapshotValidatorsCollection(options.snapshotPastValidatorsFilePath)
+      assert(
+        pastSnapshotValidatorsCollection.epoch === snapshotValidatorsCollection.epoch -1,
+        "Epoch loaded from argument data '--snapshot-past-validators-file-path' has to be one less than the current snapshot epoch, " +
+        `but validators epoch is ${snapshotValidatorsCollection.epoch} and past validators is ${pastSnapshotValidatorsCollection.epoch}`
+      )
+    }
+
     const sourceDataOverrides = getValidatorOverrides(snapshotValidatorsCollection)
+    const increaseCommissionsMap = this.getChangeCommissionsMap(
+      snapshotValidatorsCollection, pastSnapshotValidatorsCollection
+    )
 
     const dsSam = new DsSamSDK({ ...config })
     const auctionDataCalculatedFromFixtures = await dsSam.run()
-    const auctionDataParsedFromFixtures: AuctionResult = JSON.parse(fs.readFileSync(options.samResultsFixtureFilePath).toString())
+    const auctionDataParsedFromFixtures: AuctionResult = JSON.parse(
+      fs.readFileSync(options.samResultsFixtureFilePath).toString()
+    )
     console.log('Winning Total PMPE parsed from static results:', auctionDataParsedFromFixtures.winningTotalPmpe)
     console.log('Winning Total PMPE calculated from static results:', auctionDataCalculatedFromFixtures.winningTotalPmpe)
 
-    const auctionValidatorsCalculatedWithOverrides = dsSam.transformValidators(await dsSam.getAggregatedData(sourceDataOverrides))
+    const aggregatedData = await dsSam.getAggregatedData(sourceDataOverrides)
+    const auctionValidatorsCalculatedWithOverrides = dsSam.transformValidators(
+      aggregatedData
+    )
     
-    const revenueExpectations = this.evaluateRevenueExpectationForAuctionValidators(auctionDataCalculatedFromFixtures.auctionData.validators, auctionValidatorsCalculatedWithOverrides)
+    const revenueExpectations = this.evaluateRevenueExpectationForAuctionValidators(
+      auctionDataCalculatedFromFixtures.auctionData.validators,
+      auctionValidatorsCalculatedWithOverrides,
+      auctionDataCalculatedFromFixtures, // TODO: difference between auction calculated and parsed data?
+      increaseCommissionsMap,
+      aggregatedData.rewards
+    )
 
     return {
       epoch: snapshotValidatorsCollection.epoch,
@@ -117,8 +163,40 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
     }
   }
 
-  evaluateRevenueExpectationForAuctionValidators = (validatorsBefore: AuctionValidator[], validatorsAfter: AuctionValidator[]): RevenueExpectation[] => {
-    const evaluation = []
+  getChangeCommissionsMap = (
+      validatorCollection: SnapshotValidatorsCollection,
+      pastValidatorCollection: SnapshotValidatorsCollection | null
+  ): ChangeCommissionsMap => {
+    const changeMap: ChangeCommissionsMap = new Map()
+
+    for (const validatorMeta of validatorCollection.validator_metas) {
+      const vote_account = validatorMeta.vote_account
+      const pastValidatorMeta = pastValidatorCollection?.validator_metas.find(
+        v => v.vote_account === vote_account
+      )
+      const inflationAfter = validatorMeta.commission / 100
+      const inflationBefore = (pastValidatorMeta?.commission ?? validatorMeta.commission) / 100
+      const mevAfter = validatorMeta.mev_commission || null
+      const mevBefore = pastValidatorMeta ? (pastValidatorMeta.mev_commission ? (pastValidatorMeta.mev_commission / 100) : null) : null
+      changeMap.set(vote_account, {
+        inflationBefore,
+        inflationAfter,
+        mevBefore,
+        mevAfter,
+      })
+    }
+
+    return changeMap
+  }
+
+  evaluateRevenueExpectationForAuctionValidators = (
+    validatorsBefore: AuctionValidator[],
+    validatorsAfter: AuctionValidator[],
+    auctionResult: AuctionResult,
+    changeCommissionsMap: ChangeCommissionsMap,
+    rewards: Rewards
+  ): RevenueExpectation[] => {
+    const evaluation: RevenueExpectation[] = []
     for (const validatorBefore of validatorsBefore) {
       const validatorAfter = validatorsAfter.find((v) => v.voteAccount === validatorBefore.voteAccount)
       if (!validatorAfter) {
@@ -135,15 +213,46 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
       const marinadeMndeTargetSol = validatorBefore.auctionStake.marinadeMndeTargetSol
       const marinadeSamTargetSol = validatorBefore.auctionStake.marinadeSamTargetSol
 
+      // verification of commission increase (rug)
+      // if validator increased commission (in comparison to last epoch) AND his auction bid is under the winning PMPE
+      // he requires to top up the difference that is not covered by the bid (the part within winning PMPE range is covered by the bid)
+      let nonBidCommissionIncreasePmpe = 0
+      const changeCommission = changeCommissionsMap.get(validatorBefore.voteAccount) ?? DEFAULT_CHANGE_COMMISSION
+      if (
+        changeCommission.inflationAfter > changeCommission.inflationBefore &&
+        auctionResult.winningTotalPmpe > validatorAfter.revShare.totalPmpe
+      ) {
+        const actualInflationPmpe = validatorAfter.revShare.inflationPmpe
+        const expectedInflationPmpe = rewards.inflationPmpe * (1.0 - changeCommission.inflationBefore) 
+        assert(
+          expectedInflationPmpe > actualInflationPmpe,
+          validatorAfter.voteAccount + ': expected inflation has to be greater to actual'
+        )
+        nonBidCommissionIncreasePmpe = Math.max(0, expectedInflationPmpe - actualInflationPmpe)
+        this.logger.debug('Validator increased commission and has not won auction', {
+          voteAccount: validatorBefore.voteAccount,
+          pastInflationCommission: changeCommission.inflationBefore,
+          inflationPmpeBefore: expectedInflationPmpe,
+          inflationPmpeAfter: actualInflationPmpe,
+          nonBidCommissionIncreasePmpe,
+          winningPmpe: auctionResult.winningTotalPmpe,
+          validatorTotalPmpe: validatorAfter.revShare.totalPmpe,
+        })
+      }
+
+
       evaluation.push({
         voteAccount: validatorBefore.voteAccount,
         expectedInflationCommission: validatorBefore.inflationCommissionDec,
         actualInflationCommission: validatorAfter.inflationCommissionDec,
+        pastInflationCommission: changeCommission.inflationBefore,
         expectedMevCommission: validatorBefore.mevCommissionDec,
         actualMevCommission: validatorAfter.mevCommissionDec,
+        pastMevCommission: changeCommission.mevBefore,
         expectedNonBidPmpe,
         actualNonBidPmpe,
         expectedSamPmpe: expectedNonBidPmpe + validatorBefore.revShare.auctionEffectiveBidPmpe,
+        nonBidCommissionIncreasePmpe,
         maxSamStake: validatorBefore.maxStakeWanted,
         samStakeShare: marinadeMndeTargetSol === 0 ? 1 : marinadeSamTargetSol / (marinadeMndeTargetSol + marinadeSamTargetSol),
         lossPerStake: Math.max(0, expectedNonBidPmpe - actualNonBidPmpe) / 1000,
@@ -191,6 +300,15 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
     description: 'Validators.json parsed from Solana snapshot',
   })
   parseOptSnapshotValidatorsFilePath(val: string) {
+    return val
+  }
+  @Option({
+    flags: '--snapshot-past-validators-file-path <string>',
+    name: 'snapshotPastValidatorsFilePath',
+    required: false,
+    description: 'Validators.json parsed from Solana snapshot from the previous epoch to --snapshot-validators-file-path',
+  })
+  parseOptSnapshotPastValidatorsFilePath(val: string) {
     return val
   }
 }


### PR DESCRIPTION
This adjustment should manage a case when the validator changes his commission and that change is not covered by bidding PMPE. In other words, adding a way for the evaluation to consider a commission rug.

This comes from the following:

1. validator's PMPE > auction winning PMPE : any commission change is covered by increased effective bid in auction out of the box, i.e. validator pays from bidding bond
2. validator's PMPE < auction winning PMPE: validator is probably not in auction, he will pay max bid for the gained stake but commission change is not covered; this case should be calculated here