### PR TITLE
[analyze-revenue] tmp fix for missing mev data

### DIFF
--- a/src/commands/analyze-revenue.cmd.ts
+++ b/src/commands/analyze-revenue.cmd.ts
@@ -126,8 +126,11 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
         continue
       }
 
-      const expectedNonBidPmpe = validatorBefore.revShare.inflationPmpe + validatorBefore.revShare.mevPmpe
-      const actualNonBidPmpe = validatorAfter.revShare.inflationPmpe + validatorAfter.revShare.mevPmpe
+      // TODO: temporary fix for wrong value of MEV commission when there is no MEV data for epoch, skipping MEV for now
+      // const expectedNonBidPmpe = validatorBefore.revShare.inflationPmpe + validatorBefore.revShare.mevPmpe
+      // const actualNonBidPmpe = validatorAfter.revShare.inflationPmpe + validatorAfter.revShare.mevPmpe
+      const expectedNonBidPmpe = validatorBefore.revShare.inflationPmpe
+      const actualNonBidPmpe = validatorAfter.revShare.inflationPmpe
 
       const marinadeMndeTargetSol = validatorBefore.auctionStake.marinadeMndeTargetSol
       const marinadeSamTargetSol = validatorBefore.auctionStake.marinadeSamTargetSol


### PR DESCRIPTION
Temporary fix: using only commission inflation, not MEV for calculations.