### PR TITLE
feat: add method for x epochs bond req

### DIFF
--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/src/constraints.ts
+++ b/packages/ds-sam-sdk/src/constraints.ts
@@ -224,3 +224,11 @@ export const bondBalanceRequiredForStakeAmount = (stakeSol: number, validator: A
   const refundableDepositPerStake = validator.revShare.totalPmpe / 1000
   return stakeSol * (bidPerStake + downtimeProtectionPerStake + refundableDepositPerStake)
 }
+
+export const bondBalanceRequiredForXEpochs = (stakeSol: number, validator: AuctionValidator, epochs: number): number => {
+  // refundableDepositPerStake * stake + downtimeProtectionPerStake * stake + bidPerStake * stake * epochs = bondBalanceSol
+  const bidPerStake = validator.revShare.bidPmpe / 1000
+  const downtimeProtectionPerStake = 0
+  const refundableDepositPerStake = validator.revShare.totalPmpe / 1000
+  return stakeSol * ((bidPerStake * epochs) + downtimeProtectionPerStake + refundableDepositPerStake)
+}


### PR DESCRIPTION
Add a new method to compute bond req for multiple epochs, by taking into account only the bid for multiple epochs (without the psr part).