### PR TITLE
20250505 reputation [GEN-4989]

### DIFF
--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -210,7 +210,7 @@ export class Auction {
   }
 
   blockInSam (vote: string) {
-    const entry = this.data.validators.find(({ voteAccount }) => voteAccount == vote)
+    const entry = this.data.validators.find(({ voteAccount }) => voteAccount === vote)
     if (entry != null) {
       entry.samBlocked = true
     }

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -296,9 +296,9 @@ export class Auction {
     let totalFactor = 1
     let factor = 1
     for (let i = 0; i < 100; i++) {
+      totalFactor *= factor
       for (const entry of this.data.validators) {
         const values = entry.values
-        totalFactor *= factor
         values.adjSpendRobustReputation *= factor
         if (entry.revShare.totalPmpe > 0) {
           values.adjMaxSpendRobustDelegation = mult * values.adjSpendRobustReputation / (entry.revShare.totalPmpe / 1000)
@@ -320,7 +320,8 @@ export class Auction {
         }
       }
 
-      factor = leftToScale / totalScalable
+      factor = Math.max(0, leftToScale) / totalScalable
+      console.log(`SCALING round ${i} # ${JSON.stringify({factor, leftToScale, totalScalable})}`)
       if (!isFinite(factor) || factor <= 1) {
         break;
       }

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -253,7 +253,11 @@ export class Auction {
         const marginalPmpeGain = Math.max(0, unboundedResult.winningTotalPmpe / counterfactualResult.winningTotalPmpe - 1)
         validator.values.spendRobustReputation += marginalPmpeGain * totalMarinadeSpend
       }
-      const marinadeActivatedStakeSolUndelegation = -Math.min(0, validator.marinadeActivatedStakeSol - (validator.auctions[0]?.marinadeActivatedStakeSol ?? 0))
+      const marinadeActivatedStakeSolUndelegation = -Math.min(
+        0,
+        validator.marinadeActivatedStakeSol
+          - (validator.auctions[0]?.marinadeActivatedStakeSol ?? 0)
+      )
       validator.values.spendRobustReputation -= marinadeActivatedStakeSolUndelegation * winningTotalPmpe / 1000
       validator.values.spendRobustReputation = Math.max(
         this.config.minSpendRobustReputation,

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -16,7 +16,7 @@ export const EPSILON = 1e-4
 
 export class Auction {
 
-  constructor (public data: AuctionData, private constraints: AuctionConstraints, private config: DsSamConfig, private debug: Debug) { }
+  constructor (private data: AuctionData, private constraints: AuctionConstraints, private config: DsSamConfig, private debug: Debug) { }
 
   distributeMndeStake () {
     this.constraints.updateStateForMnde(this.data)
@@ -205,6 +205,10 @@ export class Auction {
     })
   }
 
+  getAuctionData (): AuctionData {
+    return this.data
+  }
+
   blockInSam (vote: string) {
     const entry = this.data.validators.find(({ voteAccount }) => voteAccount == vote)
     if (entry != null) {
@@ -241,6 +245,7 @@ export class Auction {
       }
       const marinadeActivatedStakeSolUndelegation = -Math.min(0, validator.marinadeActivatedStakeSol - (validator.auctions[0]?.marinadeActivatedStakeSol ?? 0))
       validator.values.spendRobustReputation -= marinadeActivatedStakeSolUndelegation * auction.winningTotalPmpe / 1000
+      validator.values.spendRobustReputation *= 1 - 1 / this.config.spendRobustReputationDecay
     })
   }
 

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -277,7 +277,10 @@ export class Auction {
       values.adjSpendRobustReputation = values.spendRobustReputation
       if (validator.revShare.totalPmpe > 0) {
         const pm = validator.revShare.totalPmpe / 1000
-        validator.maxBondDelegation = Math.min((validator.bondBalanceSol ?? 0) / pm, 0.04 * marinadeTvlSol)
+        validator.maxBondDelegation = Math.min(
+          (validator.bondBalanceSol ?? 0) / pm,
+          this.config.maxMarinadeTvlSharePerValidatorDec * marinadeTvlSol
+        )
       } else {
         validator.maxBondDelegation = 0
       }

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -26,9 +26,9 @@ const setReputation = (validator: AuctionValidator, values: ReputationValues): R
       adjSpendRobustReputation: validator.values.adjSpendRobustReputation,
       adjMaxSpendRobustDelegation: validator.values.adjMaxSpendRobustDelegation,
     }
-    validator.values.spendRobustReputation = validator.values.spendRobustReputation
-    validator.values.adjSpendRobustReputation = validator.values.adjSpendRobustReputation
-    validator.values.adjMaxSpendRobustDelegation = validator.values.adjMaxSpendRobustDelegation
+    validator.values.spendRobustReputation = values.spendRobustReputation
+    validator.values.adjSpendRobustReputation = values.adjSpendRobustReputation
+    validator.values.adjMaxSpendRobustDelegation = values.adjMaxSpendRobustDelegation
     return oldValues
   }
 

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -219,7 +219,7 @@ export class Auction {
   reset () {
     console.log('----------------------------- resetting auction')
     this.data.stakeAmounts.marinadeRemainingMndeSol = this.data.stakeAmounts.marinadeMndeTvlSol
-    this.data.stakeAmounts.marinadeRemainingSamSol =  this.data.stakeAmounts.marinadeSamTvlSol
+    this.data.stakeAmounts.marinadeRemainingSamSol = this.data.stakeAmounts.marinadeSamTvlSol
     this.data.validators.forEach(validator => {
       validator.auctionStake.marinadeMndeTargetSol = 0
       validator.auctionStake.marinadeSamTargetSol = 0

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -280,7 +280,9 @@ export class Auction {
 
   evaluate (): AuctionResult {
     const result = this.evaluateOne()
-    this.updateSpendRobustReputations(result)
+    if (this.config.spendRobustReputationMult != null) {
+      this.updateSpendRobustReputations(result)
+    }
     return result
   }
 

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -14,6 +14,24 @@ const logValidators = (validators: AuctionValidator[]) => {
 
 export const EPSILON = 1e-4
 
+type ReputationValues = {
+  spendRobustReputation: number
+  adjSpendRobustReputation: number
+  adjMaxSpendRobustDelegation: number
+}
+
+const setReputation = (validator: AuctionValidator, values: ReputationValues): ReputationValues => {
+    const oldValues = {
+      spendRobustReputation: validator.values.spendRobustReputation,
+      adjSpendRobustReputation: validator.values.adjSpendRobustReputation,
+      adjMaxSpendRobustDelegation: validator.values.adjMaxSpendRobustDelegation,
+    }
+    validator.values.spendRobustReputation = validator.values.spendRobustReputation
+    validator.values.adjSpendRobustReputation = validator.values.adjSpendRobustReputation
+    validator.values.adjMaxSpendRobustDelegation = validator.values.adjMaxSpendRobustDelegation
+    return oldValues
+  }
+
 export class Auction {
 
   constructor (private data: AuctionData, private constraints: AuctionConstraints, private config: DsSamConfig, private debug: Debug) { }
@@ -249,10 +267,16 @@ export class Auction {
         // baseline auction - the validator is not bounded by its reputation
         this.reset()
         console.log(`EVALUATING baseline auction for ${validator.voteAccount}`)
-        const origReputation = values.spendRobustReputation
-        values.spendRobustReputation = Infinity
+        const origReputation = setReputation(
+          validator,
+          {
+            spendRobustReputation: Infinity,
+            adjSpendRobustReputation: Infinity,
+            adjMaxSpendRobustDelegation: Infinity,
+          },
+        )
         const unboundedResult = this.evaluateOne()
-        values.spendRobustReputation = origReputation
+        setReputation(validator, origReputation)
 
         // the reputation is the gain the validator's participation brings
         const marginalPmpeGain = Math.max(0, unboundedResult.winningTotalPmpe / counterfactualResult.winningTotalPmpe - 1)

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -32,6 +32,12 @@ export type DsSamConfig = {
   maxMarinadeTvlSharePerValidatorDec: number
   spendRobustReputationMult: number | null
   spendRobustReputationDecayEpochs: number
+  minSpendRobustReputation: number
+  minScaledSpendRobustReputation: number
+  maxSpendRobustReputation: number
+  initialSpendRobustReputation: number
+  minBondBalanceSol: number
+  spendRobustReputationBondBoostCoef: number
 
   debugVoteAccounts: string[]
 }
@@ -61,7 +67,13 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   maxNetworkStakeConcentrationPerAsoDec: 0.3,
   maxMarinadeTvlSharePerValidatorDec: 0.04,
   spendRobustReputationMult: null,
-  spendRobustReputationDecayEpochs: 30,
+  spendRobustReputationDecayEpochs: 50,
+  minSpendRobustReputation: -20,
+  minScaledSpendRobustReputation: 40,
+  maxSpendRobustReputation: 1000,
+  initialSpendRobustReputation: 1,
+  minBondBalanceSol: 0,
+  spendRobustReputationBondBoostCoef: 0,
 
   debugVoteAccounts: [],
 }

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -59,7 +59,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   maxNetworkStakeConcentrationPerCountryDec: 0.3,
   maxNetworkStakeConcentrationPerAsoDec: 0.3,
   maxMarinadeTvlSharePerValidatorDec: 0.04,
-  spendRobustReputationMult: 0.5,
+  spendRobustReputationMult: null,
 
   debugVoteAccounts: [],
 }

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -30,7 +30,7 @@ export type DsSamConfig = {
   maxNetworkStakeConcentrationPerCountryDec: number
   maxNetworkStakeConcentrationPerAsoDec: number
   maxMarinadeTvlSharePerValidatorDec: number
-  spendRobustReputationMult: number
+  spendRobustReputationMult: number | null
 
   debugVoteAccounts: string[]
 }

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -31,6 +31,7 @@ export type DsSamConfig = {
   maxNetworkStakeConcentrationPerAsoDec: number
   maxMarinadeTvlSharePerValidatorDec: number
   spendRobustReputationMult: number | null
+  spendRobustReputationDecayEpochs: number
 
   debugVoteAccounts: string[]
 }
@@ -60,6 +61,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   maxNetworkStakeConcentrationPerAsoDec: 0.3,
   maxMarinadeTvlSharePerValidatorDec: 0.04,
   spendRobustReputationMult: null,
+  spendRobustReputationDecayEpochs: 30,
 
   debugVoteAccounts: [],
 }

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -74,7 +74,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   minScaledSpendRobustReputation: 40,
   maxSpendRobustReputation: 1000,
   initialSpendRobustReputation: 1,
-  minBondBalanceSol: 0,
+  minBondBalanceSol: 10,
   spendRobustReputationBondBoostCoef: 0,
 
   debugVoteAccounts: [],

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -30,6 +30,7 @@ export type DsSamConfig = {
   maxNetworkStakeConcentrationPerCountryDec: number
   maxNetworkStakeConcentrationPerAsoDec: number
   maxMarinadeTvlSharePerValidatorDec: number
+  spendRobustReputationMult: number
 
   debugVoteAccounts: string[]
 }
@@ -58,6 +59,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   maxNetworkStakeConcentrationPerCountryDec: 0.3,
   maxNetworkStakeConcentrationPerAsoDec: 0.3,
   maxMarinadeTvlSharePerValidatorDec: 0.04,
+  spendRobustReputationMult: 0.5,
 
   debugVoteAccounts: [],
 }

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -15,6 +15,7 @@ export type DsSamConfig = {
   blacklistApiBaseUrl: string
   snapshotsApiBaseUrl: string
   scoringApiBaseUrl: string
+  overridesApiBaseUrl: string
 
   rewardsEpochsCount: number
   validatorsUptimeEpochsCount: number
@@ -49,6 +50,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   bondsApiBaseUrl: 'https://validator-bonds-api.marinade.finance',
   tvlInfoApiBaseUrl: 'https://api.marinade.finance',
   blacklistApiBaseUrl: 'https://raw.githubusercontent.com/marinade-finance/delegation-strategy-2/master',
+  overridesApiBaseUrl: 'https://raw.githubusercontent.com/marinade-finance/ds-sam-pipeline/main/overrides',
   snapshotsApiBaseUrl: 'https://snapshots-api.marinade.finance',
   scoringApiBaseUrl:  'https://scoring.marinade.finance',
 

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -50,7 +50,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   bondsApiBaseUrl: 'https://validator-bonds-api.marinade.finance',
   tvlInfoApiBaseUrl: 'https://api.marinade.finance',
   blacklistApiBaseUrl: 'https://raw.githubusercontent.com/marinade-finance/delegation-strategy-2/master',
-  overridesApiBaseUrl: 'https://raw.githubusercontent.com/marinade-finance/ds-sam-pipeline/main/overrides',
+  overridesApiBaseUrl: 'https://raw.githubusercontent.com/marinade-finance/ds-sam-pipeline/main/epochs',
   snapshotsApiBaseUrl: 'https://snapshots-api.marinade.finance',
   scoringApiBaseUrl:  'https://scoring.marinade.finance',
 

--- a/packages/ds-sam-sdk/src/constraints.ts
+++ b/packages/ds-sam-sdk/src/constraints.ts
@@ -206,7 +206,11 @@ export class AuctionConstraints {
       this.config.spendRobustReputationMult != null
         && validator.revShare.totalPmpe > 0
     ) {
-      return 1000 * this.config.spendRobustReputationMult * validator.values.spendRobustReputation / validator.revShare.totalPmpe
+      return Math.max(
+        this.config.spendRobustReputationMult
+          * validator.values.spendRobustReputation / (validator.revShare.totalPmpe / 1000),
+        validator.marinadeActivatedStakeSol
+      )
     } else {
       return Infinity
     }
@@ -221,8 +225,7 @@ export const bondStakeCapSam = (validator: AuctionValidator): number => {
   const downtimeProtectionPerStake = 0
   const refundableDepositPerStake = validator.revShare.totalPmpe / 1000
   const bondBalanceSol = Math.max((validator.bondBalanceSol ?? 0) - bondBalanceUsedForMnde(validator), 0)
-  const scalingCoef = 1 // Math.min(3, Math.max(1, Math.log(bondBalanceSol) / 2))
-  return scalingCoef * bondBalanceSol / (refundableDepositPerStake + downtimeProtectionPerStake + bidPerStake)
+  return bondBalanceSol / (refundableDepositPerStake + downtimeProtectionPerStake + bidPerStake)
 }
 
 export const bondStakeCapMnde = (validator: AuctionValidator): number => {

--- a/packages/ds-sam-sdk/src/constraints.ts
+++ b/packages/ds-sam-sdk/src/constraints.ts
@@ -207,7 +207,7 @@ export class AuctionConstraints {
   }
 
   private reputationStakeCap (validator: AuctionValidator) {
-    return 1000 * this.config.spendRobustReputationMult * validator.spendRobustReputation / validator.revShare.totalPmpe
+    return 1000 * (this.config.spendRobustReputationMult ?? Infinity) * validator.spendRobustReputation / validator.revShare.totalPmpe
   }
 
 }

--- a/packages/ds-sam-sdk/src/constraints.ts
+++ b/packages/ds-sam-sdk/src/constraints.ts
@@ -201,16 +201,9 @@ export class AuctionConstraints {
     }))
   }
 
-  private reputationStakeCap (validator: AuctionValidator) {
-    if (
-      this.config.spendRobustReputationMult != null
-        && validator.revShare.totalPmpe > 0
-    ) {
-      return Math.max(
-        this.config.spendRobustReputationMult
-          * validator.values.spendRobustReputation / (validator.revShare.totalPmpe / 1000),
-        validator.marinadeActivatedStakeSol
-      )
+  private reputationStakeCap (validator: AuctionValidator): number {
+    if (this.config.spendRobustReputationMult != null) {
+      return Math.max(validator.values.adjMaxSpendRobustDelegation, validator.marinadeActivatedStakeSol)
     } else {
       return Infinity
     }

--- a/packages/ds-sam-sdk/src/constraints.ts
+++ b/packages/ds-sam-sdk/src/constraints.ts
@@ -207,7 +207,11 @@ export class AuctionConstraints {
   }
 
   private reputationStakeCap (validator: AuctionValidator) {
-    return 1000 * (this.config.spendRobustReputationMult ?? Infinity) * validator.spendRobustReputation / validator.revShare.totalPmpe
+    if (this.config.spendRobustReputationMult != null) {
+      return 1000 * this.config.spendRobustReputationMult * validator.values.spendRobustReputation / validator.revShare.totalPmpe
+    } else {
+      return Infinity
+    }
   }
 
 }
@@ -219,7 +223,8 @@ export const bondStakeCapSam = (validator: AuctionValidator): number => {
   const downtimeProtectionPerStake = 0
   const refundableDepositPerStake = validator.revShare.totalPmpe / 1000
   const bondBalanceSol = Math.max((validator.bondBalanceSol ?? 0) - bondBalanceUsedForMnde(validator), 0)
-  return bondBalanceSol / (refundableDepositPerStake + downtimeProtectionPerStake + bidPerStake)
+  const scalingCoef = 1 // Math.min(3, Math.max(1, Math.log(bondBalanceSol) / 2))
+  return scalingCoef * bondBalanceSol / (refundableDepositPerStake + downtimeProtectionPerStake + bidPerStake)
 }
 
 export const bondStakeCapMnde = (validator: AuctionValidator): number => {

--- a/packages/ds-sam-sdk/src/constraints.ts
+++ b/packages/ds-sam-sdk/src/constraints.ts
@@ -64,13 +64,8 @@ export class AuctionConstraints {
       ...this.buildAsoConcentrationConstraints(auctionData),
       ...this.buildSamBondConstraints(auctionData),
       ...this.buildValidatorConcentrationConstraints(auctionData),
+      ...this.buildReputationConstraints(auctionData),
     ]
-    if (auctionData.epoch >= 785) {
-      this.constraints = [
-        ...this.constraints,
-        ...this.buildReputationConstraints(auctionData),
-      ]
-    }
     this.updateConstraintsPerValidator()
   }
 
@@ -207,7 +202,10 @@ export class AuctionConstraints {
   }
 
   private reputationStakeCap (validator: AuctionValidator) {
-    if (this.config.spendRobustReputationMult != null) {
+    if (
+      this.config.spendRobustReputationMult != null
+        && validator.revShare.totalPmpe > 0
+    ) {
       return 1000 * this.config.spendRobustReputationMult * validator.values.spendRobustReputation / validator.revShare.totalPmpe
     } else {
       return Infinity

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -11,7 +11,7 @@ export type RawScoredValidatorDto = {
   }
   marinadeSamTargetSol: number
   values?: {
-    spendRobustReputation: number
+    spendRobustReputation?: number
   }
   marinadeActivatedStakeSol: number
   epoch: number

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -8,6 +8,8 @@ export type RawScoredValidatorDto = {
     totalPmpe: number
   }
   marinadeSamTargetSol: number
+  spendRobustReputation: number
+  marinadeActivatedStakeSol: number
   epoch: number
 }
 
@@ -22,7 +24,9 @@ export type AuctionHistoryStats = {
   winningTotalPmpe: number
   auctionEffectiveBidPmpe: number
   effParticipatingBidPmpe: number
+  spendRobustReputation: number
   bidPmpe: number
+  marinadeActivatedStakeSol: number
 }
 
 export type RawMndeVoteDto = {

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -28,9 +28,9 @@ export type AuctionHistoryStats = {
   winningTotalPmpe: number
   auctionEffectiveBidPmpe: number
   effParticipatingBidPmpe: number
-  spendRobustReputation?: number
   bidPmpe: number
-  marinadeActivatedStakeSol: number
+  spendRobustReputation?: number
+  marinadeActivatedStakeSol?: number
 }
 
 export type RawMndeVoteDto = {

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -1,3 +1,5 @@
+import { AuctionValidator } from '../types'
+
 export type RawScoredValidatorDto = {
   voteAccount: string
   revShare: {
@@ -26,7 +28,7 @@ export type AuctionHistoryStats = {
   winningTotalPmpe: number
   auctionEffectiveBidPmpe: number
   effParticipatingBidPmpe: number
-  spendRobustReputation: number
+  spendRobustReputation?: number
   bidPmpe: number
   marinadeActivatedStakeSol: number
 }
@@ -122,9 +124,12 @@ export type RawSourceData = {
   mndeVotes: RawMndeVotesResponseDto
   rewards: RawRewardsResponseDto
   auctions: RawScoredValidatorDto[]
+  overrides?: RawOverrideDataDto
 }
 
-
+export type RawOverrideDataDto = {
+  validators: AuctionValidator[]
+}
 
 export type SourceDataOverrides = {
   inflationCommissions: Map<String, number>

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -31,6 +31,7 @@ export type AuctionHistoryStats = {
   bidPmpe: number
   spendRobustReputation?: number
   marinadeActivatedStakeSol?: number
+  adjSpendRobustReputationInflationFactor?: number
 }
 
 export type RawMndeVoteDto = {

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -8,7 +8,9 @@ export type RawScoredValidatorDto = {
     totalPmpe: number
   }
   marinadeSamTargetSol: number
-  spendRobustReputation: number
+  values?: {
+    spendRobustReputation: number
+  }
   marinadeActivatedStakeSol: number
   epoch: number
 }

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+ import axios from 'axios'
 import { DsSamConfig, InputsSource } from '../config'
 import {
   RawBlacklistResponseDto,
@@ -140,6 +140,8 @@ export class DataProvider {
             ?? this.config.initialSpendRobustReputation,
           adjSpendRobustReputation: 0,
           adjMaxSpendRobustDelegation: 0,
+          marinadeActivatedStakeSolUndelegation: 0,
+          adjSpendRobustReputationInflationFactor: auctions[0]?.adjSpendRobustReputationInflationFactor ?? 1,
         },
         mndeVotesSolValue: validatorMndeVotes.mul(solPerMnde).toNumber(),
         mndeStakeCapIncrease: validatorMndeStakeCapIncrease.toNumber(),

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -86,7 +86,7 @@ export class DataProvider {
         auctionEffectiveBidPmpe: 0,
         bidPmpe: 0,
         effParticipatingBidPmpe: 0,
-        spendRobustReputation: entry?.values?.spendRobustReputation ?? 0,
+        spendRobustReputation: entry?.values?.spendRobustReputation ?? entry.bondBalanceSol,
         marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
       }
     }
@@ -96,7 +96,7 @@ export class DataProvider {
       auctionEffectiveBidPmpe: revShare.auctionEffectiveBidPmpe,
       bidPmpe: revShare.bidPmpe,
       effParticipatingBidPmpe: calcEffParticipatingBidPmpe(revShare, auction.winningTotalPmpe),
-      spendRobustReputation: entry?.values?.spendRobustReputation ?? 0,
+      spendRobustReputation: entry?.values?.spendRobustReputation ?? entry.bondBalanceSol,
       marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
     }
   }

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -86,7 +86,7 @@ export class DataProvider {
         auctionEffectiveBidPmpe: 0,
         bidPmpe: 0,
         effParticipatingBidPmpe: 0,
-        spendRobustReputation: entry?.spendRobustReputation ?? 0,
+        spendRobustReputation: entry?.values?.spendRobustReputation ?? 0,
         marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
       }
     }
@@ -96,7 +96,7 @@ export class DataProvider {
       auctionEffectiveBidPmpe: revShare.auctionEffectiveBidPmpe,
       bidPmpe: revShare.bidPmpe,
       effParticipatingBidPmpe: calcEffParticipatingBidPmpe(revShare, auction.winningTotalPmpe),
-      spendRobustReputation: entry?.spendRobustReputation ?? 0,
+      spendRobustReputation: entry?.values?.spendRobustReputation ?? 0,
       marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
     }
   }
@@ -129,7 +129,9 @@ export class DataProvider {
         mevCommissionDec,
         bidCpmpe: bond ? new Decimal(bond.cpmpe).div(1e9).toNumber() : null,
         maxStakeWanted: null,
-        spendRobustReputation: auctions[0]?.spendRobustReputation ?? 0,
+        values: {
+          spendRobustReputation: auctions[0]?.spendRobustReputation ?? 0,
+        },
         mndeVotesSolValue: validatorMndeVotes.mul(solPerMnde).toNumber(),
         mndeStakeCapIncrease: validatorMndeStakeCapIncrease.toNumber(),
         epochStats: validator.epoch_stats.filter(({ epoch_end_at }) => !!epoch_end_at).map(es => ({

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -100,7 +100,7 @@ export class DataProvider {
       bidPmpe: revShare.bidPmpe,
       effParticipatingBidPmpe: calcEffParticipatingBidPmpe(revShare, auction.winningTotalPmpe),
       spendRobustReputation: entry?.values?.spendRobustReputation,
-      marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
+      marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol,
     }
   }
 

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -80,7 +80,6 @@ export class DataProvider {
   extractAuctionHistoryStats (auction: AuctionHistory, validator: RawValidatorDto): AuctionHistoryStats {
     const entry = auction.data.find(({ voteAccount }) => validator.vote_account === voteAccount)
     const revShare = entry?.revShare
-    const bondBalanceSol = bond ? new Decimal(bond.effective_amount).div(1e9).toNumber() : 0
     if (revShare == null) {
       console.log(`validator ${validator.vote_account} did not participate in auction in epoch ${auction.epoch}`)
       return  {

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -77,7 +77,7 @@ export class DataProvider {
     return result
   }
 
-  extractAuctionHistoryStats (auction: AuctionHistory, validator: RawValidatorDto, bond?: RawBondDto): AuctionHistoryStats {
+  extractAuctionHistoryStats (auction: AuctionHistory, validator: RawValidatorDto): AuctionHistoryStats {
     const entry = auction.data.find(({ voteAccount }) => validator.vote_account === voteAccount)
     const revShare = entry?.revShare
     const bondBalanceSol = bond ? new Decimal(bond.effective_amount).div(1e9).toNumber() : 0
@@ -119,7 +119,7 @@ export class DataProvider {
 
       const inflationCommissionDec = (inflationCommissionOverride ?? validator.commission_effective ?? validator.commission_advertised ?? 100) / 100
       const mevCommissionDec = (mevCommissionOverride !== undefined ? mevCommissionOverride / 10_000 : (mev ? mev.mev_commission_bps / 10_000 : null))
-      const auctions = auctionsData.map((auction) => this.extractAuctionHistoryStats(auction, validator, bond))
+      const auctions = auctionsData.map((auction) => this.extractAuctionHistoryStats(auction, validator))
       const bondBalanceSol = bond ? new Decimal(bond.effective_amount).div(1e9).toNumber() : null
       return {
         voteAccount: validator.vote_account,

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -1,4 +1,4 @@
- import axios from 'axios'
+import axios from 'axios'
 import { DsSamConfig, InputsSource } from '../config'
 import {
   RawBlacklistResponseDto,

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -89,7 +89,7 @@ export class DataProvider {
         auctionEffectiveBidPmpe: 0,
         bidPmpe: 0,
         effParticipatingBidPmpe: 0,
-        spendRobustReputation: entry?.values?.spendRobustReputation ?? this.config.initialSpendRobustReputation,
+        spendRobustReputation: entry?.values?.spendRobustReputation,
         marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
       }
     }
@@ -120,9 +120,7 @@ export class DataProvider {
       const inflationCommissionDec = (inflationCommissionOverride ?? validator.commission_effective ?? validator.commission_advertised ?? 100) / 100
       const mevCommissionDec = (mevCommissionOverride !== undefined ? mevCommissionOverride / 10_000 : (mev ? mev.mev_commission_bps / 10_000 : null))
       const auctions = auctionsData.map((auction) => this.extractAuctionHistoryStats(auction, validator, bond))
-
       const bondBalanceSol = bond ? new Decimal(bond.effective_amount).div(1e9).toNumber() : null
-
       return {
         voteAccount: validator.vote_account,
         clientVersion: validator.version ?? '0.0.0',
@@ -137,7 +135,11 @@ export class DataProvider {
         bidCpmpe: bond ? new Decimal(bond.cpmpe).div(1e9).toNumber() : null,
         maxStakeWanted: null,
         values: {
-          spendRobustReputation: override?.values.spendRobustReputation ?? auctions[0]?.spendRobustReputation ?? this.config.initialSpendRobustReputation,
+          spendRobustReputation: override?.values.spendRobustReputation
+            ?? auctions[0]?.spendRobustReputation
+            ?? this.config.initialSpendRobustReputation,
+          adjSpendRobustReputation: 0,
+          adjMaxSpendRobustDelegation: 0,
         },
         mndeVotesSolValue: validatorMndeVotes.mul(solPerMnde).toNumber(),
         mndeStakeCapIncrease: validatorMndeStakeCapIncrease.toNumber(),

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -216,7 +216,7 @@ export class DataProvider {
         .slice(1) // header row
         .map((line) => line.trim().split(',')[0])
         .filter((value): value is string => !!value)
-                        ),
+      ),
     }
   }
 

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -86,6 +86,8 @@ export class DataProvider {
         auctionEffectiveBidPmpe: 0,
         bidPmpe: 0,
         effParticipatingBidPmpe: 0,
+        spendRobustReputation: entry?.spendRobustReputation ?? 0,
+        marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
       }
     }
     return {
@@ -93,7 +95,9 @@ export class DataProvider {
       winningTotalPmpe: auction.winningTotalPmpe,
       auctionEffectiveBidPmpe: revShare.auctionEffectiveBidPmpe,
       bidPmpe: revShare.bidPmpe,
-      effParticipatingBidPmpe: calcEffParticipatingBidPmpe(revShare, auction.winningTotalPmpe)
+      effParticipatingBidPmpe: calcEffParticipatingBidPmpe(revShare, auction.winningTotalPmpe),
+      spendRobustReputation: entry?.spendRobustReputation ?? 0,
+      marinadeActivatedStakeSol: entry?.marinadeActivatedStakeSol ?? 0,
     }
   }
 
@@ -125,6 +129,7 @@ export class DataProvider {
         mevCommissionDec,
         bidCpmpe: bond ? new Decimal(bond.cpmpe).div(1e9).toNumber() : null,
         maxStakeWanted: null,
+        spendRobustReputation: auctions[0]?.spendRobustReputation ?? 0,
         mndeVotesSolValue: validatorMndeVotes.mul(solPerMnde).toNumber(),
         mndeStakeCapIncrease: validatorMndeStakeCapIncrease.toNumber(),
         epochStats: validator.epoch_stats.filter(({ epoch_end_at }) => !!epoch_end_at).map(es => ({
@@ -173,11 +178,14 @@ export class DataProvider {
       validatorsMndeStakeCapIncreases.set(validatorVoteAccount, amount.mul(effectiveMndeStakeCapIncrease).mul(tvlSol).div(totalMndeVotes))
     }
 
+    const epoch = data.auctions.reduce((epoch, validator) => Math.max(epoch, validator.epoch), 0) + 1
+
     const solPerMnde = totalMndeVotes.gt(0) ? new Decimal(effectiveMndeTvlShareSol).div(totalMndeVotes.sub(delStratVotes)).toNumber() : 0
     console.log('total mnde votes', totalMndeVotes)
     console.log('SOL per MNDE', solPerMnde)
     console.log('tvl', tvlSol)
     return {
+      epoch,
       validators: this.aggregateValidators(data, validatorsMndeVotes, solPerMnde, validatorsMndeStakeCapIncreases, dataOverrides),
       rewards: {
         inflationPmpe: this.aggregateRewardsRecords(activatedStakePerEpochs, data.rewards.rewards_inflation_est),

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -141,7 +141,7 @@ export class DataProvider {
           adjSpendRobustReputation: 0,
           adjMaxSpendRobustDelegation: 0,
           marinadeActivatedStakeSolUndelegation: 0,
-          adjSpendRobustReputationInflationFactor: auctions[0]?.adjSpendRobustReputationInflationFactor ?? 1,
+          adjSpendRobustReputationInflationFactor: 0,
         },
         mndeVotesSolValue: validatorMndeVotes.mul(solPerMnde).toNumber(),
         mndeStakeCapIncrease: validatorMndeStakeCapIncrease.toNumber(),

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -38,6 +38,7 @@ export class DsSamSDK {
       marinadeCountryStakeCapSol: marinadeTotalTvlSol * this.config.maxMarinadeStakeConcentrationPerCountryDec,
       marinadeAsoStakeCapSol: marinadeTotalTvlSol * this.config.maxMarinadeStakeConcentrationPerAsoDec,
       marinadeValidatorStakeCapSol: marinadeTotalTvlSol * this.config.maxMarinadeTvlSharePerValidatorDec,
+      spendRobustReputationMult: this.config.spendRobustReputationMult,
     }
     this.debug.pushInfo('auction constraints', JSON.stringify(constraints))
     return new AuctionConstraints(constraints, debug)

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -107,20 +107,22 @@ export class DsSamSDK {
     })
   }
 
-  async run (data: AggregatedData | null = null): Promise<AuctionResult> {
-    const aggregatedData = data ?? await this.getAggregatedData()
-
+  async auction (): Promise<Auction> {
+    const aggregatedData = await this.getAggregatedData()
     const constraints = this.getAuctionConstraints(aggregatedData, this.debug)
     const auctionData: AuctionData = { ...aggregatedData, validators: this.transformValidators(aggregatedData) }
+    return new Auction(auctionData, constraints, this.config, this.debug)
+  }
 
-    const auction = new Auction(auctionData, constraints, this.config, this.debug)
+  async run (): Promise<AuctionResult> {
+    const auction = await this.auction()
     const result = auction.evaluate()
     console.log(`==============================\n${this.debug.formatInfo()}\n${this.debug.formatEvents()}\n==============================`)
     return result
   }
 
-  async getAggregatedData (dataOverrides: SourceDataOverrides | null = null, data: RawSourceData | null = null): Promise<AggregatedData> {
-    const sourceData = data ?? this.config.inputsSource === InputsSource.FILES ? this.dataProvider.parseCachedSourceData() : await this.dataProvider.fetchSourceData()
+  async getAggregatedData (dataOverrides: SourceDataOverrides | null = null): Promise<AggregatedData> {
+    const sourceData = this.config.inputsSource === InputsSource.FILES ? this.dataProvider.parseCachedSourceData() : await this.dataProvider.fetchSourceData()
     return this.dataProvider.aggregateData(sourceData, dataOverrides)
   }
 }

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -21,7 +21,7 @@ export const defaultDataProviderBuilder = (config: DsSamConfig) => new DataProvi
 export class DsSamSDK {
   readonly config: DsSamConfig
   private readonly debug: Debug
-  readonly dataProvider: DataProvider
+  private readonly dataProvider: DataProvider
 
   constructor (config: Partial<DsSamConfig> = {}, dataProviderBuilder = defaultDataProviderBuilder) {
     this.config = { ...DEFAULT_CONFIG, ...config }

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -39,6 +39,7 @@ export class DsSamSDK {
       marinadeAsoStakeCapSol: marinadeTotalTvlSol * this.config.maxMarinadeStakeConcentrationPerAsoDec,
       marinadeValidatorStakeCapSol: marinadeTotalTvlSol * this.config.maxMarinadeTvlSharePerValidatorDec,
       spendRobustReputationMult: this.config.spendRobustReputationMult,
+      minBondBalanceSol: this.config.minBondBalanceSol,
     }
     this.debug.pushInfo('auction constraints', JSON.stringify(constraints))
     return new AuctionConstraints(constraints, debug)

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -110,7 +110,11 @@ export class DsSamSDK {
   async auction (): Promise<Auction> {
     const aggregatedData = await this.getAggregatedData()
     const constraints = this.getAuctionConstraints(aggregatedData, this.debug)
-    const auctionData: AuctionData = { ...aggregatedData, validators: this.transformValidators(aggregatedData) }
+    const auctionData: AuctionData = {
+      ...aggregatedData,
+      validators: this.transformValidators(aggregatedData),
+      adjSpendRobustReputationInflationFactor: 1,
+    }
     return new Auction(auctionData, constraints, this.config, this.debug)
   }
 

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -113,7 +113,6 @@ export class DsSamSDK {
     const auctionData: AuctionData = {
       ...aggregatedData,
       validators: this.transformValidators(aggregatedData),
-      adjSpendRobustReputationInflationFactor: 1,
     }
     return new Auction(auctionData, constraints, this.config, this.debug)
   }

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -8,7 +8,6 @@ export type AuctionResult = {
 
 export type AuctionData = Omit<AggregatedData, 'validators'> & {
   validators: AuctionValidator[]
-  adjSpendRobustReputationInflationFactor: number
 }
 
 export type StakeAmounts = {
@@ -77,6 +76,8 @@ export type AuctionValidatorValues = {
   spendRobustReputation: number
   adjMaxSpendRobustDelegation: number
   adjSpendRobustReputation: number
+  marinadeActivatedStakeSolUndelegation: number
+  adjSpendRobustReputationInflationFactor: number
 }
 
 export type Rewards = {

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -44,6 +44,7 @@ export type AuctionValidator = AggregatedValidator & {
   bidTooLowPenalty: BidTooLowPenalty
   mndeEligible: boolean
   samEligible: boolean
+  samBlocked: boolean
   auctionStake: ValidatorAuctionStake
   lastCapConstraint: AuctionConstraint | null
   stakePriority: number
@@ -66,8 +67,12 @@ export type AggregatedValidator = {
   mndeStakeCapIncrease: number
   mndeVotesSolValue: number
   epochStats: EpochStats[]
-  spendRobustReputation: number
   auctions: AuctionHistoryStats[]
+  values: AuctionValidatorValues
+}
+
+export type AuctionValidatorValues = {
+  spendRobustReputation: number
 }
 
 export type Rewards = {

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -51,8 +51,6 @@ export type AuctionValidator = AggregatedValidator & {
   stakePriority: number
   unstakePriority: number
   maxBondDelegation: number
-  adjMaxSpendRobustDelegation: number
-  adjSpendRobustReputation: number
 }
 
 export type AggregatedValidator = {
@@ -77,6 +75,8 @@ export type AggregatedValidator = {
 
 export type AuctionValidatorValues = {
   spendRobustReputation: number
+  adjMaxSpendRobustDelegation: number
+  adjSpendRobustReputation: number
 }
 
 export type Rewards = {

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -8,6 +8,7 @@ export type AuctionResult = {
 
 export type AuctionData = Omit<AggregatedData, 'validators'> & {
   validators: AuctionValidator[]
+  adjSpendRobustReputationInflationFactor: number
 }
 
 export type StakeAmounts = {
@@ -49,6 +50,9 @@ export type AuctionValidator = AggregatedValidator & {
   lastCapConstraint: AuctionConstraint | null
   stakePriority: number
   unstakePriority: number
+  maxBondDelegation: number
+  adjMaxSpendRobustDelegation: number
+  adjSpendRobustReputation: number
 }
 
 export type AggregatedValidator = {

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -19,6 +19,7 @@ export type StakeAmounts = {
 }
 
 export type AggregatedData = {
+  epoch: number
   validators: AggregatedValidator[]
   rewards: Rewards
   stakeAmounts: StakeAmounts
@@ -65,6 +66,7 @@ export type AggregatedValidator = {
   mndeStakeCapIncrease: number
   mndeVotesSolValue: number
   epochStats: EpochStats[]
+  spendRobustReputation: number
   auctions: AuctionHistoryStats[]
 }
 
@@ -94,6 +96,7 @@ export type AuctionConstraintsConfig = {
   marinadeCountryStakeCapSol: number
   marinadeAsoStakeCapSol: number
   marinadeValidatorStakeCapSol: number
+  spendRobustReputationMult: number
 }
 
 export enum AuctionConstraintType {
@@ -102,6 +105,7 @@ export enum AuctionConstraintType {
   VALIDATOR = 'VALIDATOR',
   BOND = 'BOND',
   MNDE = 'MNDE',
+  REPUTATION = 'REPUTATION',
 }
 
 export type AuctionConstraint = {

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -96,7 +96,7 @@ export type AuctionConstraintsConfig = {
   marinadeCountryStakeCapSol: number
   marinadeAsoStakeCapSol: number
   marinadeValidatorStakeCapSol: number
-  spendRobustReputationMult: number
+  spendRobustReputationMult: number | null
 }
 
 export enum AuctionConstraintType {

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -107,6 +107,7 @@ export type AuctionConstraintsConfig = {
   marinadeAsoStakeCapSol: number
   marinadeValidatorStakeCapSol: number
   spendRobustReputationMult: number | null
+  minBondBalanceSol: number
 }
 
 export enum AuctionConstraintType {

--- a/packages/ds-sam-sdk/src/utils.ts
+++ b/packages/ds-sam-sdk/src/utils.ts
@@ -17,7 +17,7 @@ export const calcValidatorRevShare = (validator: AggregatedValidator, rewards: R
   }
 }
 
-export const calcEffParticipatingBidPmpe = (revShare: { inflationPmpe: number, mevPmpe: number }, winningTotalPmpe: number) => {
+export const calcEffParticipatingBidPmpe = (revShare: { inflationPmpe: number, mevPmpe: number }, winningTotalPmpe: number): number => {
   return Math.max(0, winningTotalPmpe - revShare.inflationPmpe - revShare.mevPmpe)
 }
 

--- a/packages/ds-sam-sdk/src/utils.ts
+++ b/packages/ds-sam-sdk/src/utils.ts
@@ -32,6 +32,9 @@ export const validatorAggDefaults = () => ({
     base: 0,
   },
   samBlocked: false,
+  maxBondDelegation: NaN,
+  adjMaxSpendRobustDelegation: NaN,
+  adjSpendRobustReputation: NaN,
 })
 
 export const validatorTotalAuctionStakeSol = (validator: AuctionValidator): number =>

--- a/packages/ds-sam-sdk/src/utils.ts
+++ b/packages/ds-sam-sdk/src/utils.ts
@@ -31,6 +31,7 @@ export const validatorAggDefaults = () => ({
     coef: 0,
     base: 0,
   },
+  samBlocked: false,
 })
 
 export const validatorTotalAuctionStakeSol = (validator: AuctionValidator): number =>

--- a/packages/ds-sam-sdk/src/utils.ts
+++ b/packages/ds-sam-sdk/src/utils.ts
@@ -33,8 +33,6 @@ export const validatorAggDefaults = () => ({
   },
   samBlocked: false,
   maxBondDelegation: NaN,
-  adjMaxSpendRobustDelegation: NaN,
-  adjSpendRobustReputation: NaN,
 })
 
 export const validatorTotalAuctionStakeSol = (validator: AuctionValidator): number =>

--- a/packages/ds-sam-sdk/tsconfig.json
+++ b/packages/ds-sam-sdk/tsconfig.json
@@ -13,7 +13,8 @@
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "composite": true,
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.spec.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "noUncheckedIndexedAccess": true,
     "sourceMap": true,
     "noImplicitAny": true,
-    "lib": ["es2021", "dom"]
+    "lib": ["es2021", "dom"],
+    "composite": true,
   },
   "include": [
     "packages/**/*.ts",


### PR DESCRIPTION
Implements a spend-based validator reputation, max stake limits based on that and also bond boosts based on the reputation.

https://www.notion.so/marinade/APY-Boost-1a8e465715a4804e9025f6b0cafff9b9?pvs=4#1ebe465715a480839e42ea0d916bacf6