### PR TITLE
[removal/deprecation] not using auctions overrides [GEN-7136]

### DIFF
--- a/packages/ds-sam-sdk/README.md
+++ b/packages/ds-sam-sdk/README.md
@@ -25,8 +25,6 @@ SDK for Marinade's DS-SAM - max yield - auction evaluation tool.
   snapshotsApiBaseUrl: string
   // Base URL of the scoring API
   scoringApiBaseUrl: string
-  // The base URL for the location of the overrides json
-  overridesApiBaseUrl: string
 
   // How many epochs in the past to fetch rewards for
   rewardsEpochsCount: number

--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/src/config.ts
+++ b/packages/ds-sam-sdk/src/config.ts
@@ -28,8 +28,6 @@ export type DsSamConfig = {
   blacklistApiBaseUrl: string
   // Base URL of the scoring API
   scoringApiBaseUrl: string
-  // The base URL for the location of the overrides json
-  overridesApiBaseUrl: string
 
   // Use zero-commission validators for backstop
   enableZeroCommissionBackstop: boolean
@@ -135,8 +133,6 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   tvlInfoApiBaseUrl: 'https://api.marinade.finance',
   // marinade proxy cache API, pointing to raw gh: 'https://raw.githubusercontent.com/marinade-finance/delegation-strategy-2/master'
   blacklistApiBaseUrl: 'https://thru.marinade.finance/marinade-finance/delegation-strategy-2/master',
-  // marinade proxy cache API, pointing to 'https://raw.githubusercontent.com/marinade-finance/ds-sam-pipeline/main/epochs'
-  overridesApiBaseUrl: 'https://thru.marinade.finance/marinade-finance/ds-sam-pipeline/main/epochs',
   scoringApiBaseUrl: 'https://scoring.marinade.finance',
 
   enableZeroCommissionBackstop: false,

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.dto.ts
@@ -1,4 +1,4 @@
-import type { AuctionValidator, CommissionDetails } from '../types'
+import type { CommissionDetails } from '../types'
 
 export type RawScoredValidatorDto = {
   voteAccount: string
@@ -129,11 +129,6 @@ export type RawSourceData = {
   blacklist: RawBlacklistResponseDto
   rewards: RawRewardsResponseDto
   auctions: RawScoredValidatorDto[]
-  overrides?: RawOverrideDataDto
-}
-
-export type RawOverrideDataDto = {
-  validators: AuctionValidator[]
 }
 
 /** All override values are in decimal (0–1) scale, e.g. 5% = 0.05; cpmpe in SOL units */

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -22,7 +22,6 @@ import type {
   AuctionHistory,
   AuctionHistoryStats,
   RawValidatorDto,
-  RawOverrideDataDto,
 } from './data-provider.dto'
 import type { DsSamConfig } from '../config'
 
@@ -153,7 +152,6 @@ export class DataProvider {
     return data.validators.validators.map((validator): AggregatedValidator => {
       const bond = data.bonds.bonds.find(({ vote_account }) => validator.vote_account === vote_account)
       const mev = data.mevInfo.validators.find(({ vote_account }) => validator.vote_account === vote_account)
-      const override = data.overrides?.validators.find(({ voteAccount }) => validator.vote_account === voteAccount)
 
       const inflationCommissionOverrideDec = dataOverrides?.inflationCommissionsDec?.get(validator.vote_account) ?? null
       const mevCommissionOverrideDec = dataOverrides?.mevCommissionsDec?.get(validator.vote_account) ?? null
@@ -225,7 +223,7 @@ export class DataProvider {
         claimableBondBalanceSol,
         lastBondBalanceSol: lastAuctionHistory?.values?.bondBalanceSol ?? null,
         lastMarinadeActivatedStakeSol: lastAuctionHistory?.values?.marinadeActivatedStakeSol ?? null,
-        lastSamBlacklisted: override?.lastSamBlacklisted ?? lastAuctionHistory?.values?.samBlacklisted ?? null,
+        lastSamBlacklisted: lastAuctionHistory?.values?.samBlacklisted ?? null,
         totalActivatedStakeSol: new Decimal(validator.activated_stake).div(1e9).toNumber(),
         marinadeActivatedStakeSol,
         inflationCommissionDec,
@@ -326,9 +324,6 @@ export class DataProvider {
     fs.writeFileSync(`${this.config.inputsCacheDirPath}/blacklist.csv`, data.blacklist)
     fs.writeFileSync(`${this.config.inputsCacheDirPath}/rewards.json`, JSON.stringify(data.rewards, null, 2))
     fs.writeFileSync(`${this.config.inputsCacheDirPath}/auctions.json`, JSON.stringify(data.auctions, null, 2))
-    if (data.overrides) {
-      fs.writeFileSync(`${this.config.inputsCacheDirPath}/overrides.json`, JSON.stringify(data.overrides, null, 2))
-    }
   }
 
   parseCachedSourceData(): RawSourceData {
@@ -360,11 +355,6 @@ export class DataProvider {
       : []
     this.fixRawScoredValidatorsDto(auctions)
 
-    const overridesFile = `${this.config.inputsCacheDirPath}/overrides.json`
-    const overrides: RawOverrideDataDto | undefined = fs.existsSync(overridesFile)
-      ? (JSON.parse(fs.readFileSync(overridesFile).toString()) as RawOverrideDataDto)
-      : undefined
-
     return {
       validators,
       mevInfo,
@@ -373,7 +363,6 @@ export class DataProvider {
       rewards,
       blacklist,
       auctions,
-      overrides,
     }
   }
 
@@ -388,9 +377,6 @@ export class DataProvider {
       this.fetchAuctions(this.config.bidTooLowPenaltyHistoryEpochs),
     ])
 
-    const epoch = rewards.rewards_inflation_est.reduce((epoch, entry) => Math.max(epoch, entry[0]), 0) + 1
-    const overrides = await this.fetchOverrides(epoch)
-
     const data = {
       validators,
       mevInfo,
@@ -399,7 +385,6 @@ export class DataProvider {
       blacklist,
       rewards,
       auctions,
-      overrides: overrides ?? undefined,
     }
     if (this.config.cacheInputs) {
       this.cacheSourceData(data)
@@ -466,18 +451,5 @@ export class DataProvider {
     const response = await axios.get<RawScoredValidatorDto[]>(url)
     this.fixRawScoredValidatorsDto(response.data)
     return response.data
-  }
-
-  async fetchOverrides(epoch: number): Promise<RawOverrideDataDto | null> {
-    const url = `${this.config.overridesApiBaseUrl}/${epoch}/overrides.json`
-    try {
-      const response = await axios.get<RawOverrideDataDto>(url)
-      return response.data
-    } catch (error: unknown) {
-      if (axios.isAxiosError(error) && error.response?.status === 404) {
-        return null
-      }
-      throw error
-    }
   }
 }


### PR DESCRIPTION
For some time, I’ve felt we should remove handling of overrides coming from the `ds-sam-pipeline` data, and I believe now is the right time 🙂

The `overrides` data was used only once, at epoch 790. I think that was long enough ago that we can safely abandon it. I have no insight into why it was used back then, but it was a long time ago, and having a constant `404` in the code is tedious and adds no value.

It also seems that this worked only together with the reputation handling, which has since been removed anyway.

Interestingly, in code, we use the value `lastSamBlacklisted`  and it seems not being part of the existing `overrides.json` data at all.

You can see the single overrides instance here: https://github.com/marinade-finance/ds-sam-pipeline/tree/main/epochs/790

Would you be supportive of this change?
