### PR TITLE
20260430 ssi [GEN-7676]

### DIFF
--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -75,22 +75,45 @@ export class DataProvider {
     return rewardsTotal.total.div(rewardsTotal.epochs).toNumber()
   }
 
-  // Single-epoch network-wide staker yield in PMPE
-  // Uses the latest epoch present in `rewards_inflation_est`.
-  // Returns null if that epoch's stake is unknown or zero.
+  // Single-epoch network-wide staker yield in PMPE for the latest epoch in rewards_inflation_est.
+  // The two reward streams are populated by independent ETLs (inflation: RPC, near-instant;
+  // block: Snowflake, lags ~1 epoch). When `rewards_block[E]` is missing for the target epoch
+  // we fill it with the median of the 3 most recent prior epochs' block rewards — empirically
+  // keeps SSI APY error within ~5 bps median, ~33 bps tail. Longer windows perform worse
+  // because block rewards trend with network activity.
   private computeSsiPmpe(
     rawRewards: RawRewardsResponseDto,
     activatedStakePerEpochs: Map<number, Decimal>,
   ): number | null {
-    const latestEpoch = rawRewards.rewards_inflation_est.reduce((max, [epoch]) => Math.max(max, epoch), -Infinity)
-    const stake = activatedStakePerEpochs.get(latestEpoch)
-    if (!stake || stake.isZero()) {
-      return null
-    }
-    const inflationSol = rawRewards.rewards_inflation_est.find(([e]) => e === latestEpoch)?.[1] ?? 0
-    const blockSol = rawRewards.rewards_block?.find(([e]) => e === latestEpoch)?.[1] ?? 0
-    // SOL (1e9 lamports) → PMPE (per 1000 lamports of stake): * 1e9 * 1000 / stake = * 1e12 / stake
+    const latest = rawRewards.rewards_inflation_est.reduce<[number, number] | null>(
+      (best, entry) => (!best || entry[0] > best[0] ? entry : best),
+      null,
+    )
+    if (!latest) return null
+    const [epoch, inflationSol] = latest
+    const stake = activatedStakePerEpochs.get(epoch)
+    if (!stake || stake.isZero()) return null
+    const blockSol = this.resolveBlockSol(rawRewards.rewards_block ?? [], epoch)
+    if (blockSol === null) return null
+    // SOL → PMPE (per 1000 lamports of stake): × 1e9 × 1000 / stake = × 1e12 / stake
     return new Decimal(inflationSol).add(blockSol).mul(1e12).div(stake).toNumber()
+  }
+
+  // Returns block_SOL for the requested epoch. Falls back to the median of the 3 most recent
+  // prior epochs' block rewards when the direct entry is missing or zero. Returns null if
+  // fewer than 3 prior values are available.
+  private resolveBlockSol(rewardsBlock: [number, number][], epoch: number): number | null {
+    // An entry present in the array is authoritative even if zero — explicit zero is a real
+    // observation. The lag we're guarding against shows up as a missing entry, not as a zero.
+    const direct = rewardsBlock.find(([e]) => e === epoch)?.[1]
+    if (direct !== undefined) return direct
+    const prior = rewardsBlock
+      .filter(([e]) => e < epoch)
+      .sort(([a], [b]) => b - a)
+      .slice(0, 3)
+      .map(([, v]) => v)
+    if (prior.length < 3) return null
+    return prior.sort((a, b) => a - b)[1] ?? null
   }
 
   /* eslint-disable no-param-reassign */

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -25,7 +25,7 @@ import type {
 } from './data-provider.dto'
 import type { DsSamConfig } from '../config'
 
-// Latest entry with a non-zero value, restricted to epochs ≤ maxEpoch (defaults to no limit).
+// Latest entry with a non-zero value, restricted to epochs ≤ maxEpoch.
 // Returns null if no such entry exists.
 const latestNonZero = (entries?: RawRewardsRecordDto[], maxEpoch = Infinity): RawRewardsRecordDto | null => {
   let best: RawRewardsRecordDto | null = null

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -75,6 +75,27 @@ export class DataProvider {
     return rewardsTotal.total.div(rewardsTotal.epochs).toNumber()
   }
 
+  // Single-epoch network-wide staker yield in PMPE (SSI; see SSI.md).
+  // Uses the latest epoch present in `rewards_inflation_est`.
+  // Returns null if that epoch's stake is unknown or zero.
+  private computeSsiPmpe(
+    rawRewards: RawRewardsResponseDto,
+    activatedStakePerEpochs: Map<number, Decimal>,
+  ): number | null {
+    if (rawRewards.rewards_inflation_est.length === 0) {
+      return null
+    }
+    const latestEpoch = rawRewards.rewards_inflation_est.reduce((max, [epoch]) => Math.max(max, epoch), -Infinity)
+    const stake = activatedStakePerEpochs.get(latestEpoch)
+    if (!stake || stake.isZero()) {
+      return null
+    }
+    const inflationSol = rawRewards.rewards_inflation_est.find(([e]) => e === latestEpoch)?.[1] ?? 0
+    const blockSol = rawRewards.rewards_block?.find(([e]) => e === latestEpoch)?.[1] ?? 0
+    // SOL (1e9 lamports) → PMPE (per 1000 lamports of stake): * 1e9 * 1000 / stake = * 1e12 / stake
+    return new Decimal(inflationSol).add(blockSol).mul(1e12).div(stake).toNumber()
+  }
+
   /* eslint-disable no-param-reassign */
   private processAuctions(input: RawScoredValidatorDto[]): AuctionHistory[] {
     const result: AuctionHistory[] = []
@@ -312,6 +333,7 @@ export class DataProvider {
         marinadeRemainingSamSol: tvlSol,
       },
       blacklist,
+      ssiPmpe: this.computeSsiPmpe(data.rewards, activatedStakePerEpochs),
     }
   }
 

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -107,8 +107,7 @@ export class DataProvider {
     if (!stake || stake.isZero()) return null
     const inflation = latestNonZero(rawRewards.rewards_inflation_est, epoch)
     if (!inflation) return null
-    // SOL → PMPE (per 1000 lamports of stake): × 1e9 × 1000 / stake = × 1e12 / stake
-    return new Decimal(inflation[1]).add(blockSol).mul(1e12).div(stake).toNumber()
+    return ((inflation[1] + blockSol) * 1e12) / stake.toNumber()
   }
 
   /* eslint-disable no-param-reassign */

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -75,7 +75,7 @@ export class DataProvider {
     return rewardsTotal.total.div(rewardsTotal.epochs).toNumber()
   }
 
-  // Single-epoch network-wide staker yield in PMPE (SSI; see SSI.md).
+  // Single-epoch network-wide staker yield in PMPE
   // Uses the latest epoch present in `rewards_inflation_est`.
   // Returns null if that epoch's stake is unknown or zero.
   private computeSsiPmpe(

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -27,8 +27,8 @@ import type { DsSamConfig } from '../config'
 
 // Latest entry with a non-zero value, restricted to epochs ≤ maxEpoch (defaults to no limit).
 // Returns null if no such entry exists.
-const latestNonZero = (entries: [number, number][] | undefined, maxEpoch = Infinity): [number, number] | null => {
-  let best: [number, number] | null = null
+const latestNonZero = (entries?: RawRewardsRecordDto[], maxEpoch = Infinity): RawRewardsRecordDto | null => {
+  let best: RawRewardsRecordDto | null = null
   for (const entry of entries ?? []) {
     const [e, v] = entry
     if (v > 0 && e <= maxEpoch && (!best || e > best[0])) {

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -82,9 +82,6 @@ export class DataProvider {
     rawRewards: RawRewardsResponseDto,
     activatedStakePerEpochs: Map<number, Decimal>,
   ): number | null {
-    if (rawRewards.rewards_inflation_est.length === 0) {
-      return null
-    }
     const latestEpoch = rawRewards.rewards_inflation_est.reduce((max, [epoch]) => Math.max(max, epoch), -Infinity)
     const stake = activatedStakePerEpochs.get(latestEpoch)
     if (!stake || stake.isZero()) {

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -30,8 +30,8 @@ import type { DsSamConfig } from '../config'
 const latestNonZero = (entries?: RawRewardsRecordDto[], maxEpoch = Infinity): RawRewardsRecordDto | null => {
   let best: RawRewardsRecordDto | null = null
   for (const entry of entries ?? []) {
-    const [e, v] = entry
-    if (v > 0 && e <= maxEpoch && (!best || e > best[0])) {
+    const [epoch, sol] = entry
+    if (sol > 0 && epoch <= maxEpoch && (!best || epoch > best[0])) {
       best = entry
     }
   }
@@ -107,7 +107,7 @@ export class DataProvider {
     if (!stake || stake.isZero()) return null
     const inflation = latestNonZero(rawRewards.rewards_inflation_est, epoch)
     if (!inflation) return null
-    return ((inflation[1] + blockSol) * 1e12) / stake.toNumber()
+    return new Decimal(inflation[1] + blockSol).mul(1e12).div(stake).toNumber()
   }
 
   /* eslint-disable no-param-reassign */

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -107,7 +107,7 @@ export class DataProvider {
     if (!stake || stake.isZero()) return null
     const inflation = latestNonZero(rawRewards.rewards_inflation_est, epoch)
     if (!inflation) return null
-    return new Decimal(inflation[1] + blockSol).mul(1e12).div(stake).toNumber()
+    return ((inflation[1] + blockSol) * 1e12) / stake.toNumber()
   }
 
   /* eslint-disable no-param-reassign */

--- a/packages/ds-sam-sdk/src/data-provider/data-provider.ts
+++ b/packages/ds-sam-sdk/src/data-provider/data-provider.ts
@@ -25,6 +25,19 @@ import type {
 } from './data-provider.dto'
 import type { DsSamConfig } from '../config'
 
+// Latest entry with a non-zero value, restricted to epochs ≤ maxEpoch (defaults to no limit).
+// Returns null if no such entry exists.
+const latestNonZero = (entries: [number, number][] | undefined, maxEpoch = Infinity): [number, number] | null => {
+  let best: [number, number] | null = null
+  for (const entry of entries ?? []) {
+    const [e, v] = entry
+    if (v > 0 && e <= maxEpoch && (!best || e > best[0])) {
+      best = entry
+    }
+  }
+  return best
+}
+
 export class DataProvider {
   constructor(
     protected readonly config: DsSamConfig,
@@ -75,45 +88,27 @@ export class DataProvider {
     return rewardsTotal.total.div(rewardsTotal.epochs).toNumber()
   }
 
-  // Single-epoch network-wide staker yield in PMPE for the latest epoch in rewards_inflation_est.
-  // The two reward streams are populated by independent ETLs (inflation: RPC, near-instant;
-  // block: Snowflake, lags ~1 epoch). When `rewards_block[E]` is missing for the target epoch
-  // we fill it with the median of the 3 most recent prior epochs' block rewards — empirically
-  // keeps SSI APY error within ~5 bps median, ~33 bps tail. Longer windows perform worse
-  // because block rewards trend with network activity.
+  // Single-epoch network-wide staker yield in PMPE.
+  // The two reward streams come from independent ETLs (inflation: RPC, near-instant; block:
+  // Snowflake, lags ~1 epoch) and can lead each other in either direction. We anchor on the
+  // freshest non-zero `rewards_block` epoch (the volatile component we care most about getting
+  // current) and use the latest non-zero `rewards_inflation_est` entry at-or-before that epoch.
+  // An explicit zero in either feed is treated as missing — these reward streams are never
+  // genuinely zero on mainnet, so a zero is an ETL artifact, not an observation.
+  // Empirically: picking inflation from the prior epoch costs ~0.4 bps APY (inflation is stable).
   private computeSsiPmpe(
     rawRewards: RawRewardsResponseDto,
     activatedStakePerEpochs: Map<number, Decimal>,
   ): number | null {
-    const latest = rawRewards.rewards_inflation_est.reduce<[number, number] | null>(
-      (best, entry) => (!best || entry[0] > best[0] ? entry : best),
-      null,
-    )
-    if (!latest) return null
-    const [epoch, inflationSol] = latest
+    const block = latestNonZero(rawRewards.rewards_block)
+    if (!block) return null
+    const [epoch, blockSol] = block
     const stake = activatedStakePerEpochs.get(epoch)
     if (!stake || stake.isZero()) return null
-    const blockSol = this.resolveBlockSol(rawRewards.rewards_block ?? [], epoch)
-    if (blockSol === null) return null
+    const inflation = latestNonZero(rawRewards.rewards_inflation_est, epoch)
+    if (!inflation) return null
     // SOL → PMPE (per 1000 lamports of stake): × 1e9 × 1000 / stake = × 1e12 / stake
-    return new Decimal(inflationSol).add(blockSol).mul(1e12).div(stake).toNumber()
-  }
-
-  // Returns block_SOL for the requested epoch. Falls back to the median of the 3 most recent
-  // prior epochs' block rewards when the direct entry is missing or zero. Returns null if
-  // fewer than 3 prior values are available.
-  private resolveBlockSol(rewardsBlock: [number, number][], epoch: number): number | null {
-    // An entry present in the array is authoritative even if zero — explicit zero is a real
-    // observation. The lag we're guarding against shows up as a missing entry, not as a zero.
-    const direct = rewardsBlock.find(([e]) => e === epoch)?.[1]
-    if (direct !== undefined) return direct
-    const prior = rewardsBlock
-      .filter(([e]) => e < epoch)
-      .sort(([a], [b]) => b - a)
-      .slice(0, 3)
-      .map(([, v]) => v)
-    if (prior.length < 3) return null
-    return prior.sort((a, b) => a - b)[1] ?? null
+    return new Decimal(inflation[1]).add(blockSol).mul(1e12).div(stake).toNumber()
   }
 
   /* eslint-disable no-param-reassign */

--- a/packages/ds-sam-sdk/src/types.ts
+++ b/packages/ds-sam-sdk/src/types.ts
@@ -22,6 +22,7 @@ export type AggregatedData = {
   rewards: Rewards
   stakeAmounts: StakeAmounts
   blacklist: Set<string>
+  ssiPmpe: number | null
 }
 
 export type EpochStats = {

--- a/packages/ds-sam-sdk/test/helpers/auction-test-utils.ts
+++ b/packages/ds-sam-sdk/test/helpers/auction-test-utils.ts
@@ -88,6 +88,7 @@ export function makeAuction(overrides: Partial<AuctionData> = {}): AuctionData {
     },
     rewards: { inflationPmpe: 0, mevPmpe: 0, blockPmpe: 0 },
     blacklist: new Set<string>(),
+    ssiPmpe: null,
     ...overrides,
   }
 }

--- a/packages/ds-sam-sdk/test/sam.test.ts
+++ b/packages/ds-sam-sdk/test/sam.test.ts
@@ -549,6 +549,7 @@ describe('sam', () => {
           marinadeRemainingSamSol: 1000,
         },
         blacklist: new Set(),
+        ssiPmpe: null,
       }
       const constraints = makeUnitConstraints()
       const auction = new Auction(data, constraints, DEFAULT_CONFIG, debug)
@@ -579,6 +580,7 @@ describe('sam', () => {
           marinadeRemainingSamSol: 1000,
         },
         blacklist: new Set(),
+        ssiPmpe: null,
       }
       const constraints = makeUnitConstraints()
       const auction = new Auction(data, constraints, DEFAULT_CONFIG, debug)

--- a/packages/ds-sam-sdk/test/ssi.test.ts
+++ b/packages/ds-sam-sdk/test/ssi.test.ts
@@ -31,7 +31,10 @@ describe('ssiPmpe', () => {
 
   it('block leads inflation: anchors on latest block, uses prior inflation', async () => {
     const { dp, raw } = await buildSdk()
-    raw.rewards.rewards_inflation_est = [[998, 100]]
+    raw.rewards.rewards_inflation_est = [
+      [998, 100],
+      [1001, 999], // ahead of block — must be ignored
+    ]
     raw.rewards.rewards_block = [[999, 50]]
     expect(dp.aggregateData(raw).ssiPmpe).toBeCloseTo(150, 9)
   })

--- a/packages/ds-sam-sdk/test/ssi.test.ts
+++ b/packages/ds-sam-sdk/test/ssi.test.ts
@@ -2,8 +2,6 @@ import { DEFAULT_CONFIG } from '../src/config'
 import { StaticDataProviderBuilder } from './helpers/static-data-provider-builder'
 import { ValidatorMockBuilder } from './helpers/validator-mock-builder'
 
-// Build a SDK + a minimal raw payload for one validator with `totalStakeSol` external stake.
-// Caller overrides `raw.rewards` to drive the cases under test.
 const buildSdk = async (totalStakeSol = 1000) => {
   const dp = new StaticDataProviderBuilder()
     .withCurrentEpoch(1000)

--- a/packages/ds-sam-sdk/test/ssi.test.ts
+++ b/packages/ds-sam-sdk/test/ssi.test.ts
@@ -1,0 +1,84 @@
+import { DEFAULT_CONFIG } from '../src/config'
+import { StaticDataProviderBuilder } from './helpers/static-data-provider-builder'
+import { ValidatorMockBuilder } from './helpers/validator-mock-builder'
+
+// Build a SDK + a minimal raw payload for one validator with `totalStakeSol` external stake.
+// Caller overrides `raw.rewards` to drive the cases under test.
+const buildSdk = async (totalStakeSol = 1000) => {
+  const dp = new StaticDataProviderBuilder()
+    .withCurrentEpoch(1000)
+    .withInflationRewardsPerEpoch(0)
+    .withMevRewardsPerEpoch(0)
+    .withBlockRewardsPerEpoch(0)
+    .withValidators([
+      new ValidatorMockBuilder('alice', 'id-a')
+        .withEligibleDefaults()
+        .withNativeStake(0)
+        .withLiquidStake(0)
+        .withExternalStake(totalStakeSol),
+    ])
+    .builder()(DEFAULT_CONFIG)
+  const raw = await dp.fetchSourceData()
+  raw.auctions = []
+  return { dp, raw }
+}
+
+describe('ssiPmpe', () => {
+  it('happy path: latest non-zero block + matching inflation', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [[999, 100]]
+    raw.rewards.rewards_block = [[999, 50]]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeCloseTo(150, 9)
+  })
+
+  it('block leads inflation: anchors on latest block, uses prior inflation', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [[998, 100]]
+    raw.rewards.rewards_block = [[999, 50]]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeCloseTo(150, 9)
+  })
+
+  it('inflation leads block: ignores newer inflation, anchors on latest block', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [
+      [998, 100],
+      [999, 999], // newer than block — must be ignored
+    ]
+    raw.rewards.rewards_block = [[998, 50]]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeCloseTo(150, 9)
+  })
+
+  it('explicit zero is treated as missing (block)', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [
+      [998, 100],
+      [999, 100],
+    ]
+    raw.rewards.rewards_block = [
+      [998, 50],
+      [999, 0], // ETL artifact — ignore and fall back to 998
+    ]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeCloseTo(150, 9)
+  })
+
+  it('returns null when no non-zero block entry exists', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [[999, 100]]
+    raw.rewards.rewards_block = [[999, 0]]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeNull()
+  })
+
+  it('returns null when no inflation entry at-or-before the block epoch', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [[1001, 100]] // only ahead of block
+    raw.rewards.rewards_block = [[999, 50]]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeNull()
+  })
+
+  it('returns null when stake is unknown for the picked epoch', async () => {
+    const { dp, raw } = await buildSdk()
+    raw.rewards.rewards_inflation_est = [[9999, 100]]
+    raw.rewards.rewards_block = [[9999, 50]]
+    expect(dp.aggregateData(raw).ssiPmpe).toBeNull()
+  })
+})

--- a/packages/ds-sam-sdk/test/updatePaidUndelegation.test.ts
+++ b/packages/ds-sam-sdk/test/updatePaidUndelegation.test.ts
@@ -40,6 +40,7 @@ describe('Auction.updatePaidUndelegation (simplified)', () => {
       },
       rewards: { inflationPmpe: NaN, mevPmpe: NaN, blockPmpe: NaN },
       blacklist: new Set<string>(),
+      ssiPmpe: null,
     }
     const auction = new Auction(
       data,

--- a/src/commands/auction.cmd.ts
+++ b/src/commands/auction.cmd.ts
@@ -66,6 +66,7 @@ export class AuctionCommand extends CommandRunner {
           blacklist: Array.from(result.auctionData.blacklist),
           validators: result.auctionData.validators.map(({ lastCapConstraint, epochStats: _, ...validator }) => ({
             ...validator,
+            ssiPmpe: result.auctionData.ssiPmpe,
             lastCapConstraint: lastCapConstraint && {
               ...lastCapConstraint,
               validators: lastCapConstraint.validators.length,


### PR DESCRIPTION
  Computes per-epoch SSI as PMPE for the latest epoch in rewards_inflation_est
  and stamps it on every validator entry in the auction output. Consumed by                                                                                                                    
  bid-distribution to dynamically cap the Marinade fee against the network                                                                                                                     
  benchmark.                                                                                                                                                                                   
                                                                                                                                                                                               
  Sources match apy-api's SSR pipeline: theoretical inflation                                                                                                                                  
  (supply × inflation_rate) + BQ rewards_validators_blocks for block fees,                                                                                                                     
  both via validators-api/rewards. MEV excluded per SSI methodology.                                                                                                                           
                                                                                                                                                                                               
  Per-epoch numbers track solstakingindex SSI within ~10 bps. The residual                                                                                                                     
  appears to come from how block rewards are sourced upstream (Flipside ETL                                                                                                                    
  vs on-chain RPC scan) — same gap apy-api SSR carries; flagged in a code                                                                                                                      
  comment for now.              

New Changes...

  Adds a network-wide ssiPmpe (per-epoch staker yield) to AggregatedData and stamps it onto every SAM-meta entry, sourced from rewards_inflation_est + rewards_block / total_activated_stake.
                                                                                                                                                                                                                                                                                                                                                                                               
  The two reward streams come from independent ETLs (inflation: RPC, instant; block: Snowflake, lags ~1 epoch). When rewards_block is missing for the target epoch, fill with the median of the 3 most recent prior epochs — empirically keeps SSI APY error within ~5 bps median, 33 bps tail. Returns null if fewer than 3 prior values exist; consumers fall back to no-cap behavior.       
                                                                                                                                                                                                                                                                                                                                                                                              