### PR TITLE
[fix] include prereleases in client version semver check [SUP-113]

### DIFF
--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/src/sdk.ts
+++ b/packages/ds-sam-sdk/src/sdk.ts
@@ -131,7 +131,11 @@ export class DsSamSDK {
           ...ineligibleValidatorAggDefaults(),
         }
       }
-      if (!semver.satisfies(validator.clientVersion, this.config.validatorsClientVersionSemverExpr)) {
+      if (
+        !semver.satisfies(validator.clientVersion, this.config.validatorsClientVersionSemverExpr, {
+          includePrerelease: true,
+        })
+      ) {
         return {
           ...validator,
           revShare,

--- a/packages/ds-sam-sdk/test/sam.test.ts
+++ b/packages/ds-sam-sdk/test/sam.test.ts
@@ -521,46 +521,33 @@ describe('sam', () => {
   })
 
   describe('client version gate', () => {
-    const buildResultForVersion = async (version: string) => {
-      const voteAccounts = generateVoteAccounts()
-      const identities = generateIdentities()
-      const target = new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-        .withEligibleDefaults()
-        .withBond({ stakeWanted: 1_000_000, cpmpe: 0.1, balance: 100 })
-        .withVersion(version)
-      const filler = Array.from({ length: 5 }, () =>
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withBond({ stakeWanted: 1_000_000, cpmpe: 0.1, balance: 100 }),
-      )
-      const dsSam = new DsSamSDK({}, defaultStaticDataProviderBuilder([target, ...filler]))
-      const result = await dsSam.run()
-      const v = result.auctionData.validators.find(x => x.voteAccount === target.voteAccount)
-      assert(v, 'target validator not found in results')
-      return v
+    const isEligible = async (version: string) => {
+      const target = new ValidatorMockBuilder('target', 'target-i').withEligibleDefaults().withVersion(version)
+      // Auction needs at least one eligible validator to compute winning PMPE.
+      const filler = new ValidatorMockBuilder('filler', 'filler-i').withEligibleDefaults()
+      const result = await new DsSamSDK({}, defaultStaticDataProviderBuilder([target, filler])).run()
+      const v = result.auctionData.validators.find(x => x.voteAccount === 'target')
+      assert(v, 'target validator not found in result')
+      return v.samEligible
     }
 
     it('accepts in-range stable Firedancer version', async () => {
-      const v = await buildResultForVersion('0.909.0')
-      expect(v.samEligible).toBe(true)
+      expect(await isEligible('0.909.0')).toBe(true)
     })
 
+    // Regression: validators-API reports harmonic FD as 0.909.0-rc.40001.
+    // node-semver excludes prereleases from ranges by default; SDK passes
+    // { includePrerelease: true } so this version is treated as in-range.
     it('accepts in-range Firedancer prerelease (harmonic FD)', async () => {
-      // Regression: validators-API reports harmonic FD as 0.909.0-rc.40001.
-      // node-semver excludes prereleases from ranges by default; the SDK must
-      // pass { includePrerelease: true } so this version is treated as in-range.
-      const v = await buildResultForVersion('0.909.0-rc.40001')
-      expect(v.samEligible).toBe(true)
+      expect(await isEligible('0.909.0-rc.40001')).toBe(true)
     })
 
     it('rejects out-of-range version', async () => {
-      const v = await buildResultForVersion('0.100.0')
-      expect(v.samEligible).toBe(false)
+      expect(await isEligible('0.100.0')).toBe(false)
     })
 
     it('rejects 0.0.0 fallback (missing version)', async () => {
-      const v = await buildResultForVersion('0.0.0')
-      expect(v.samEligible).toBe(false)
+      expect(await isEligible('0.0.0')).toBe(false)
     })
   })
 

--- a/packages/ds-sam-sdk/test/sam.test.ts
+++ b/packages/ds-sam-sdk/test/sam.test.ts
@@ -520,6 +520,50 @@ describe('sam', () => {
     })
   })
 
+  describe('client version gate', () => {
+    const buildResultForVersion = async (version: string) => {
+      const voteAccounts = generateVoteAccounts()
+      const identities = generateIdentities()
+      const target = new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
+        .withEligibleDefaults()
+        .withBond({ stakeWanted: 1_000_000, cpmpe: 0.1, balance: 100 })
+        .withVersion(version)
+      const filler = Array.from({ length: 5 }, () =>
+        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
+          .withEligibleDefaults()
+          .withBond({ stakeWanted: 1_000_000, cpmpe: 0.1, balance: 100 }),
+      )
+      const dsSam = new DsSamSDK({}, defaultStaticDataProviderBuilder([target, ...filler]))
+      const result = await dsSam.run()
+      const v = result.auctionData.validators.find(x => x.voteAccount === target.voteAccount)
+      assert(v, 'target validator not found in results')
+      return v
+    }
+
+    it('accepts in-range stable Firedancer version', async () => {
+      const v = await buildResultForVersion('0.909.0')
+      expect(v.samEligible).toBe(true)
+    })
+
+    it('accepts in-range Firedancer prerelease (harmonic FD)', async () => {
+      // Regression: validators-API reports harmonic FD as 0.909.0-rc.40001.
+      // node-semver excludes prereleases from ranges by default; the SDK must
+      // pass { includePrerelease: true } so this version is treated as in-range.
+      const v = await buildResultForVersion('0.909.0-rc.40001')
+      expect(v.samEligible).toBe(true)
+    })
+
+    it('rejects out-of-range version', async () => {
+      const v = await buildResultForVersion('0.100.0')
+      expect(v.samEligible).toBe(false)
+    })
+
+    it('rejects 0.0.0 fallback (missing version)', async () => {
+      const v = await buildResultForVersion('0.0.0')
+      expect(v.samEligible).toBe(false)
+    })
+  })
+
   describe('auction unit', () => {
     it('samBlocked=true filtered from distribution', () => {
       const debug = new Debug(new Set())


### PR DESCRIPTION
validators-API reports harmonic Firedancer as 0.909.0-rc.40001; node-semver excludes prereleases from ranges by default, which flipped affected validators to ineligible during the upgrade window.