### PR TITLE
[release] tag on release [trivial][GEN-7997]

### DIFF
--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc --build",
     "test": "pnpm jest --config ../../jest.config.js --testPathPatterns=\"$(pwd)\"",
-    "prepack": "pnpm test && pnpm build"
+    "prepack": "pnpm test && pnpm build",
+    "postpublish": "if git tag -a v$npm_package_version -m \"Release v$npm_package_version\" 2>/dev/null; then echo \"Tag v$npm_package_version created locally. Push it with: git push <remote> v$npm_package_version\"; else echo \"Tag v$npm_package_version already exists (or could not be created). If it points to the right commit, push with: git push <remote> v$npm_package_version\"; fi"
   },
   "files": [
     "dist",


### PR DESCRIPTION
After `pnpm publish` succeeds, the publish flow creates a local annotated `v<version> git tag` and prints the exact git `push <remote> v<version>` command the developer should run.
Purpose: nudge the developer to push the tag - our `release.yml` workflow only fires on a `v*.*.*` tag push, and forgetting that step was the reason GitHub Releases were routinely missing after npm publishes.