### PR TITLE
[tests+analyze-revenue] fix calculation of commission charge [GEN-7037]

### DIFF
--- a/packages/ds-sam-sdk/test/bidTooLowPenaltyCommission.test.ts
+++ b/packages/ds-sam-sdk/test/bidTooLowPenaltyCommission.test.ts
@@ -1,7 +1,7 @@
-import { calcBidTooLowPenalty, calcValidatorRevShare } from '../src/calculations'
+import { calcBidTooLowPenalty, calcEffParticipatingBidPmpe, calcValidatorRevShare } from '../src/calculations'
 import { effectiveCommissions } from '../src/utils'
 
-import type { RevShare } from '../src/types'
+import type { CommissionDetails, RevShare } from '../src/types'
 import type { AuctionValidator } from '../src/types'
 
 const REWARDS = { inflationPmpe: 0.4, mevPmpe: 0.05, blockPmpe: 0 }
@@ -9,30 +9,38 @@ const BID = 0.005
 const PERMITTED_DEVIATION = 0.01
 const HISTORY_EPOCHS = 3
 
-const revShareFor = (onchainInflationDec: number, inBondInflationDec: number | null, bidCpmpe: number): RevShare => {
+const commissionsFor = (onchainInflationDec: number, inBondInflationDec: number | null): CommissionDetails => {
   const effective = effectiveCommissions(onchainInflationDec, inBondInflationDec, 0, null)
-  return calcValidatorRevShare(
+  return {
+    inflationCommissionDec: effective.inflationDec,
+    mevCommissionDec: effective.mevDec ?? 1,
+    blockRewardsCommissionDec: 1,
+    inflationCommissionOnchainDec: onchainInflationDec,
+    inflationCommissionInBondDec: inBondInflationDec,
+    mevCommissionOnchainDec: 0,
+    mevCommissionInBondDec: null,
+    blockRewardsCommissionInBondDec: null,
+  }
+}
+
+const revShareFor = (
+  onchainInflationDec: number,
+  inBondInflationDec: number | null,
+  bidCpmpe: number,
+): RevShare & { commissions: CommissionDetails } => {
+  const commissions = commissionsFor(onchainInflationDec, inBondInflationDec)
+  const revShare = calcValidatorRevShare(
     {
       voteAccount: 'validator',
-      inflationCommissionDec: effective.inflationDec,
-      mevCommissionDec: effective.mevDec,
+      inflationCommissionDec: commissions.inflationCommissionDec,
+      mevCommissionDec: commissions.mevCommissionDec,
       blockRewardsCommissionDec: null,
       bidCpmpe,
-      values: {
-        commissions: {
-          inflationCommissionDec: effective.inflationDec,
-          mevCommissionDec: effective.mevDec ?? 1,
-          blockRewardsCommissionDec: 1,
-          inflationCommissionOnchainDec: onchainInflationDec,
-          inflationCommissionInBondDec: inBondInflationDec,
-          mevCommissionOnchainDec: 0,
-          mevCommissionInBondDec: null,
-          blockRewardsCommissionInBondDec: null,
-        },
-      },
+      values: { commissions },
     },
     REWARDS,
   )
+  return { ...revShare, commissions }
 }
 
 const penaltyFor = ({
@@ -41,21 +49,23 @@ const penaltyFor = ({
   pastEffParticipating,
   pastBidPmpe,
 }: {
-  revShare: RevShare
+  revShare: RevShare & { commissions: CommissionDetails }
   winningTotalPmpe: number
   pastEffParticipating: number[]
   pastBidPmpe: number
 }) => {
-  revShare.effParticipatingBidPmpe = Math.max(0, winningTotalPmpe - revShare.onchainDistributedPmpe)
+  revShare.effParticipatingBidPmpe = calcEffParticipatingBidPmpe(revShare, winningTotalPmpe)
   const validator = {
     revShare,
     auctions: pastEffParticipating.map(effParticipatingBidPmpe => ({
       effParticipatingBidPmpe,
       bidPmpe: pastBidPmpe,
+      // past 0%-commission era; relevant once the commission trigger gets re-enabled
+      commissions: commissionsFor(0, null),
     })),
     bidTooLowPenalty: { coef: NaN, base: NaN },
     marinadeActivatedStakeSol: 100000,
-    values: { commissions: null },
+    values: { commissions: revShare.commissions },
   } as unknown as AuctionValidator
   return calcBidTooLowPenalty({
     historyEpochs: HISTORY_EPOCHS,

--- a/packages/ds-sam-sdk/test/bidTooLowPenaltyCommission.test.ts
+++ b/packages/ds-sam-sdk/test/bidTooLowPenaltyCommission.test.ts
@@ -79,14 +79,22 @@ const penaltyFor = ({
 // path is shared with the bid trigger, so scenarios force it via a marginal bid decrease.
 const TRIGGERING_PAST_BID = BID * 1.01
 
+// effParticipatingBidPmpe = winningTotalPmpe - onchainDistributedPmpe: the slice of the
+// clearing price the bond must cover, NOT the validator's own bid — so it INCREASES
+// when commission increases (less gets distributed on-chain)
+const effParticipatingFor = (onchainInflationDec: number, winningTotalPmpe: number): number =>
+  calcEffParticipatingBidPmpe(revShareFor(onchainInflationDec, null, BID), winningTotalPmpe)
+
 describe('bid too low penalty on commission changes (GEN-7037 exploration)', () => {
   it('commission raise alone does not fire the penalty today (commission trigger disabled)', () => {
+    const winningTotalPmpe = 0.455
     const revShare = revShareFor(0.05, null, BID)
     expect(revShare.bondObligationPmpe).toBeCloseTo(BID, 12)
+    const zeroEraEff = effParticipatingFor(0, winningTotalPmpe)
     const res = penaltyFor({
       revShare,
-      winningTotalPmpe: 0.455,
-      pastEffParticipating: [0.005, 0.005, 0.005],
+      winningTotalPmpe,
+      pastEffParticipating: [zeroEraEff, zeroEraEff, zeroEraEff],
       pastBidPmpe: BID,
     })
     expect(res.bidTooLowPenalty.coef).toBe(0)
@@ -102,12 +110,14 @@ describe('bid too low penalty on commission changes (GEN-7037 exploration)', () 
   })
 
   it('onchain raise 0% -> 5% with no in-bond config yields zero fee even when the trigger fires', () => {
+    const winningTotalPmpe = 0.455
     const revShare = revShareFor(0.05, null, BID)
+    // floor still holds the 0%-commission era values W - G = 0.005
+    const zeroEraEff = effParticipatingFor(0, winningTotalPmpe)
     const res = penaltyFor({
       revShare,
-      winningTotalPmpe: 0.455,
-      // floor still holds the 0%-commission era values W - G = 0.005
-      pastEffParticipating: [0.005, 0.005, 0.005],
+      winningTotalPmpe,
+      pastEffParticipating: [zeroEraEff, zeroEraEff, zeroEraEff],
       pastBidPmpe: TRIGGERING_PAST_BID,
     })
     expect(revShare.effParticipatingBidPmpe).toBeCloseTo(0.025, 12)
@@ -128,10 +138,11 @@ describe('bid too low penalty on commission changes (GEN-7037 exploration)', () 
     const revShare = revShareFor(0.05, 0.02, BID)
     expect(revShare.totalPmpe).toBeGreaterThanOrEqual(winningTotalPmpe)
     expect(revShare.bondObligationPmpe).toBeCloseTo(0.017, 12)
+    const pastEff = effParticipatingFor(0.05, winningTotalPmpe)
     const res = penaltyFor({
       revShare,
       winningTotalPmpe,
-      pastEffParticipating: [0.01, 0.01, 0.01],
+      pastEffParticipating: [pastEff, pastEff, pastEff],
       pastBidPmpe: TRIGGERING_PAST_BID,
     })
     expect(res.bidTooLowPenalty.coef).toBe(0)
@@ -140,7 +151,8 @@ describe('bid too low penalty on commission changes (GEN-7037 exploration)', () 
 
   it('the 1% slack does not renew: a second small in-bond step pays a fee', () => {
     const winningTotalPmpe = 0.44
-    const floor = 0.01
+    const floor = effParticipatingFor(0.05, winningTotalPmpe)
+    expect(floor).toBeCloseTo(0.01, 12)
     const withinSlack = revShareFor(0.05, 0.0376, BID)
     expect(withinSlack.bondObligationPmpe).toBeCloseTo(0.00996, 12)
     const first = penaltyFor({
@@ -166,16 +178,22 @@ describe('bid too low penalty on commission changes (GEN-7037 exploration)', () 
     expect(second.bidTooLowPenalty.coef).toBeGreaterThan(0)
   })
 
-  it('full 0% -> 5% effective jump is free within the 3-epoch history window and maximal after it', () => {
+  it('0% -> 5% raise stays free only while pre-raise epochs keep the history floor low', () => {
     const winningTotalPmpe = 0.455
     const revShare = revShareFor(0.05, 0.05, BID)
     expect(revShare.bondObligationPmpe).toBeCloseTo(BID, 12)
+
+    // the penalty limit is the min of the current and the historical eff participating values
+    const raisedEff = effParticipatingFor(0.05, winningTotalPmpe)
+    const zeroEraEff = effParticipatingFor(0, winningTotalPmpe)
+    expect(raisedEff).toBeCloseTo(0.025, 12)
+    expect(zeroEraEff).toBeCloseTo(0.005, 12)
 
     // onchain was raised last epoch; older history still holds the low 0%-era floor
     const withinWindow = penaltyFor({
       revShare: revShareFor(0.05, 0.05, BID),
       winningTotalPmpe,
-      pastEffParticipating: [0.025, 0.005, 0.005],
+      pastEffParticipating: [raisedEff, zeroEraEff, zeroEraEff],
       pastBidPmpe: TRIGGERING_PAST_BID,
     })
     expect(withinWindow.bidTooLowPenalty.coef).toBe(0)
@@ -183,21 +201,22 @@ describe('bid too low penalty on commission changes (GEN-7037 exploration)', () 
     const afterWindow = penaltyFor({
       revShare: revShareFor(0.05, 0.05, BID),
       winningTotalPmpe,
-      pastEffParticipating: [0.025, 0.025, 0.025],
+      pastEffParticipating: [raisedEff, raisedEff, raisedEff],
       pastBidPmpe: TRIGGERING_PAST_BID,
     })
     expect(afterWindow.bidTooLowPenalty.coef).toBe(1)
-    expect(afterWindow.bidTooLowPenaltyPmpe).toBeCloseTo(winningTotalPmpe + 0.025, 12)
+    expect(afterWindow.bidTooLowPenaltyPmpe).toBeCloseTo(winningTotalPmpe + raisedEff, 12)
   })
 
   it('overshooting onchain commission keeps bondObligationPmpe above the floor at 5% effective', () => {
     const winningTotalPmpe = 0.455
     const revShare = revShareFor(0.1, 0.05, BID)
     expect(revShare.bondObligationPmpe).toBeCloseTo(0.025, 12)
+    const pastEff = effParticipatingFor(0.05, winningTotalPmpe)
     const res = penaltyFor({
       revShare,
       winningTotalPmpe,
-      pastEffParticipating: [0.025, 0.025, 0.025],
+      pastEffParticipating: [pastEff, pastEff, pastEff],
       pastBidPmpe: TRIGGERING_PAST_BID,
     })
     expect(res.bidTooLowPenalty.coef).toBe(0)

--- a/packages/ds-sam-sdk/test/bidTooLowPenaltyCommission.test.ts
+++ b/packages/ds-sam-sdk/test/bidTooLowPenaltyCommission.test.ts
@@ -1,0 +1,196 @@
+import { calcBidTooLowPenalty, calcValidatorRevShare } from '../src/calculations'
+import { effectiveCommissions } from '../src/utils'
+
+import type { RevShare } from '../src/types'
+import type { AuctionValidator } from '../src/types'
+
+const REWARDS = { inflationPmpe: 0.4, mevPmpe: 0.05, blockPmpe: 0 }
+const BID = 0.005
+const PERMITTED_DEVIATION = 0.01
+const HISTORY_EPOCHS = 3
+
+const revShareFor = (onchainInflationDec: number, inBondInflationDec: number | null, bidCpmpe: number): RevShare => {
+  const effective = effectiveCommissions(onchainInflationDec, inBondInflationDec, 0, null)
+  return calcValidatorRevShare(
+    {
+      voteAccount: 'validator',
+      inflationCommissionDec: effective.inflationDec,
+      mevCommissionDec: effective.mevDec,
+      blockRewardsCommissionDec: null,
+      bidCpmpe,
+      values: {
+        commissions: {
+          inflationCommissionDec: effective.inflationDec,
+          mevCommissionDec: effective.mevDec ?? 1,
+          blockRewardsCommissionDec: 1,
+          inflationCommissionOnchainDec: onchainInflationDec,
+          inflationCommissionInBondDec: inBondInflationDec,
+          mevCommissionOnchainDec: 0,
+          mevCommissionInBondDec: null,
+          blockRewardsCommissionInBondDec: null,
+        },
+      },
+    },
+    REWARDS,
+  )
+}
+
+const penaltyFor = ({
+  revShare,
+  winningTotalPmpe,
+  pastEffParticipating,
+  pastBidPmpe,
+}: {
+  revShare: RevShare
+  winningTotalPmpe: number
+  pastEffParticipating: number[]
+  pastBidPmpe: number
+}) => {
+  revShare.effParticipatingBidPmpe = Math.max(0, winningTotalPmpe - revShare.onchainDistributedPmpe)
+  const validator = {
+    revShare,
+    auctions: pastEffParticipating.map(effParticipatingBidPmpe => ({
+      effParticipatingBidPmpe,
+      bidPmpe: pastBidPmpe,
+    })),
+    bidTooLowPenalty: { coef: NaN, base: NaN },
+    marinadeActivatedStakeSol: 100000,
+    values: { commissions: null },
+  } as unknown as AuctionValidator
+  return calcBidTooLowPenalty({
+    historyEpochs: HISTORY_EPOCHS,
+    winningTotalPmpe,
+    validator,
+    permittedBidDeviation: PERMITTED_DEVIATION,
+  })
+}
+
+// The commission-based trigger is disabled in calcBidTooLowPenalty; the penalty magnitude
+// path is shared with the bid trigger, so scenarios force it via a marginal bid decrease.
+const TRIGGERING_PAST_BID = BID * 1.01
+
+describe('bid too low penalty on commission changes (GEN-7037 exploration)', () => {
+  it('commission raise alone does not fire the penalty today (commission trigger disabled)', () => {
+    const revShare = revShareFor(0.05, null, BID)
+    expect(revShare.bondObligationPmpe).toBeCloseTo(BID, 12)
+    const res = penaltyFor({
+      revShare,
+      winningTotalPmpe: 0.455,
+      pastEffParticipating: [0.005, 0.005, 0.005],
+      pastBidPmpe: BID,
+    })
+    expect(res.bidTooLowPenalty.coef).toBe(0)
+    expect(res.bidTooLowPenaltyPmpe).toBe(0)
+  })
+
+  it('onchain raise 0% -> 5% with no in-bond config keeps bondObligationPmpe untouched', () => {
+    const before = revShareFor(0, null, BID)
+    const after = revShareFor(0.05, null, BID)
+    expect(after.bondObligationPmpe).toBeCloseTo(before.bondObligationPmpe, 12)
+    expect(after.onchainDistributedPmpe).toBeCloseTo(before.onchainDistributedPmpe - 0.02, 12)
+    expect(after.totalPmpe).toBeCloseTo(before.totalPmpe - 0.02, 12)
+  })
+
+  it('onchain raise 0% -> 5% with no in-bond config yields zero fee even when the trigger fires', () => {
+    const revShare = revShareFor(0.05, null, BID)
+    const res = penaltyFor({
+      revShare,
+      winningTotalPmpe: 0.455,
+      // floor still holds the 0%-commission era values W - G = 0.005
+      pastEffParticipating: [0.005, 0.005, 0.005],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    expect(revShare.effParticipatingBidPmpe).toBeCloseTo(0.025, 12)
+    expect(res.bidTooLowPenalty.coef).toBe(0)
+    expect(res.bidTooLowPenaltyPmpe).toBe(0)
+  })
+
+  it('onchain raise with in-bond pinned at 0% keeps totalPmpe and moves the cost to the bond', () => {
+    const before = revShareFor(0, 0, BID)
+    const after = revShareFor(0.05, 0, BID)
+    expect(after.totalPmpe).toBeCloseTo(before.totalPmpe, 12)
+    expect(before.bondObligationPmpe).toBeCloseTo(BID, 12)
+    expect(after.bondObligationPmpe).toBeCloseTo(BID + 0.02, 12)
+  })
+
+  it('in-bond raise that keeps totalPmpe above the clearing price pays no fee', () => {
+    const winningTotalPmpe = 0.44
+    const revShare = revShareFor(0.05, 0.02, BID)
+    expect(revShare.totalPmpe).toBeGreaterThanOrEqual(winningTotalPmpe)
+    expect(revShare.bondObligationPmpe).toBeCloseTo(0.017, 12)
+    const res = penaltyFor({
+      revShare,
+      winningTotalPmpe,
+      pastEffParticipating: [0.01, 0.01, 0.01],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    expect(res.bidTooLowPenalty.coef).toBe(0)
+    expect(res.bidTooLowPenaltyPmpe).toBe(0)
+  })
+
+  it('the 1% slack does not renew: a second small in-bond step pays a fee', () => {
+    const winningTotalPmpe = 0.44
+    const floor = 0.01
+    const withinSlack = revShareFor(0.05, 0.0376, BID)
+    expect(withinSlack.bondObligationPmpe).toBeCloseTo(0.00996, 12)
+    const first = penaltyFor({
+      revShare: withinSlack,
+      winningTotalPmpe,
+      pastEffParticipating: [floor, floor, floor],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    expect(first.bidTooLowPenalty.coef).toBe(0)
+
+    // next epoch the floor is unchanged (effParticipating tracks clearing price, not own commitment)
+    const nextStep = revShareFor(0.05, 0.0378, BID)
+    expect(nextStep.bondObligationPmpe).toBeCloseTo(0.00988, 12)
+    const second = penaltyFor({
+      revShare: nextStep,
+      winningTotalPmpe,
+      pastEffParticipating: [floor, floor, floor],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    const adjustedLimit = floor * (1 - PERMITTED_DEVIATION)
+    const expectedCoef = Math.min(1, Math.sqrt((1.5 * (adjustedLimit - nextStep.bondObligationPmpe)) / adjustedLimit))
+    expect(second.bidTooLowPenalty.coef).toBeCloseTo(expectedCoef, 12)
+    expect(second.bidTooLowPenalty.coef).toBeGreaterThan(0)
+  })
+
+  it('full 0% -> 5% effective jump is free within the 3-epoch history window and maximal after it', () => {
+    const winningTotalPmpe = 0.455
+    const revShare = revShareFor(0.05, 0.05, BID)
+    expect(revShare.bondObligationPmpe).toBeCloseTo(BID, 12)
+
+    // onchain was raised last epoch; older history still holds the low 0%-era floor
+    const withinWindow = penaltyFor({
+      revShare: revShareFor(0.05, 0.05, BID),
+      winningTotalPmpe,
+      pastEffParticipating: [0.025, 0.005, 0.005],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    expect(withinWindow.bidTooLowPenalty.coef).toBe(0)
+
+    const afterWindow = penaltyFor({
+      revShare: revShareFor(0.05, 0.05, BID),
+      winningTotalPmpe,
+      pastEffParticipating: [0.025, 0.025, 0.025],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    expect(afterWindow.bidTooLowPenalty.coef).toBe(1)
+    expect(afterWindow.bidTooLowPenaltyPmpe).toBeCloseTo(winningTotalPmpe + 0.025, 12)
+  })
+
+  it('overshooting onchain commission keeps bondObligationPmpe above the floor at 5% effective', () => {
+    const winningTotalPmpe = 0.455
+    const revShare = revShareFor(0.1, 0.05, BID)
+    expect(revShare.bondObligationPmpe).toBeCloseTo(0.025, 12)
+    const res = penaltyFor({
+      revShare,
+      winningTotalPmpe,
+      pastEffParticipating: [0.025, 0.025, 0.025],
+      pastBidPmpe: TRIGGERING_PAST_BID,
+    })
+    expect(res.bidTooLowPenalty.coef).toBe(0)
+    expect(res.bidTooLowPenaltyPmpe).toBe(0)
+  })
+})

--- a/src/commands/analyze-revenue.cmd.ts
+++ b/src/commands/analyze-revenue.cmd.ts
@@ -77,6 +77,12 @@ export type RevenueExpectation = {
 export const loadSnapshotValidatorsCollection = (path: string): SnapshotValidatorsCollection =>
   JSON.parse(fs.readFileSync(path).toString()) as SnapshotValidatorsCollection
 
+export const snapshotOnchainCommissions = (validatorMeta: SnapshotValidatorMeta): PastValidatorCommissions => ({
+  inflation: validatorMeta.commission / 100,
+  // mev_commission is validator_commission_bps from Jito TipDistributionAccount
+  mev: validatorMeta.mev_commission != null ? validatorMeta.mev_commission / 10_000 : null,
+})
+
 export const getValidatorOverrides = (
   snapshotValidatorsCollection: SnapshotValidatorsCollection,
   bonds: RawBondsResponseDto,
@@ -91,13 +97,12 @@ export const getValidatorOverrides = (
   for (const validatorMeta of snapshotValidatorsCollection.validator_metas) {
     const bond = bondsByVoteAccount.get(validatorMeta.vote_account)
 
-    const inflationOnchainDec = validatorMeta.commission / 100
+    const onchain = snapshotOnchainCommissions(validatorMeta)
     const inflationBondDec =
       bond?.inflation_commission_bps != null ? Number(bond.inflation_commission_bps) / 10_000 : null
-    const mevOnchainDec = validatorMeta.mev_commission != null ? validatorMeta.mev_commission / 10_000 : null
     const mevBondDec = bond?.mev_commission_bps != null ? Number(bond.mev_commission_bps) / 10_000 : null
 
-    const effective = effectiveCommissions(inflationOnchainDec, inflationBondDec, mevOnchainDec, mevBondDec)
+    const effective = effectiveCommissions(onchain.inflation, inflationBondDec, onchain.mev, mevBondDec)
 
     inflationCommissionsDec.set(validatorMeta.vote_account, effective.inflationDec)
     mevCommissionsDec.set(validatorMeta.vote_account, effective.mevDec ?? undefined)
@@ -206,14 +211,7 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
     }
 
     for (const validatorMeta of pastValidatorCollection.validator_metas) {
-      const voteAccount = validatorMeta.vote_account
-      const inflationLastEpoch = validatorMeta.commission / 100
-      // mev_commission is validator_commission_bps from Jito TipDistributionAccount
-      const mevLastEpoch = validatorMeta.mev_commission != null ? validatorMeta.mev_commission / 10_000 : null
-      commissionMap.set(voteAccount, {
-        inflation: inflationLastEpoch,
-        mev: mevLastEpoch,
-      })
+      commissionMap.set(validatorMeta.vote_account, snapshotOnchainCommissions(validatorMeta))
     }
 
     return commissionMap
@@ -248,15 +246,18 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
       let beforeSamCommissionIncreasePmpe = 0
       const lastEpochCommissions = pastValidatorCommissions.get(validatorBefore.voteAccount)
       // without the past snapshot data (--snapshot-past-validators-file-path) nothing is charged
-      if (lastEpochCommissions != null && auctionResult.winningTotalPmpe > validatorAfter.revShare.totalPmpe) {
+      if (lastEpochCommissions != null && auctionResult.winningTotalPmpe > validatorBefore.revShare.totalPmpe) {
         const samInflationPmpe = validatorBefore.revShare.inflationPmpe
         const samMevPmpe = validatorBefore.revShare.mevPmpe
         const lastEpochInflationPmpe = rewards.inflationPmpe * (1.0 - lastEpochCommissions.inflation)
         const lastEpochMevPmpe =
           lastEpochCommissions.mev == null ? null : rewards.mevPmpe * (1.0 - lastEpochCommissions.mev)
-        const inflationIncreasePmpe = Math.max(0, lastEpochInflationPmpe - samInflationPmpe)
-        const mevIncreasePmpe = lastEpochMevPmpe == null ? 0 : Math.max(0, lastEpochMevPmpe - samMevPmpe)
-        beforeSamCommissionIncreasePmpe = inflationIncreasePmpe + mevIncreasePmpe
+        // combined delta: downstream charges combined non-bid PMPE, so a decrease in one commission offsets an increase in the other
+        const lastEpochMevBasePmpe = lastEpochMevPmpe ?? samMevPmpe
+        beforeSamCommissionIncreasePmpe = Math.max(
+          0,
+          lastEpochInflationPmpe + lastEpochMevBasePmpe - (samInflationPmpe + samMevPmpe),
+        )
         if (beforeSamCommissionIncreasePmpe > 0) {
           this.logger.debug('Validator increased commission before SAM run and has not won auction', {
             voteAccount: validatorBefore.voteAccount,
@@ -268,7 +269,7 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
             samMevPmpe,
             beforeSamCommissionIncreasePmpe,
             winningPmpe: auctionResult.winningTotalPmpe,
-            validatorTotalPmpe: validatorAfter.revShare.totalPmpe,
+            validatorTotalPmpe: validatorBefore.revShare.totalPmpe,
           })
         }
       }
@@ -277,6 +278,7 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
         voteAccount: validatorBefore.voteAccount,
         expectedInflationCommission: validatorBefore.inflationCommissionDec,
         actualInflationCommission: validatorAfter.inflationCommissionDec,
+        // 0 may also mean missing past snapshot data; beforeSamCommissionIncreasePmpe is 0 in that case too
         pastInflationCommission: lastEpochCommissions?.inflation ?? 0,
         expectedMevCommission: validatorBefore.mevCommissionDec,
         actualMevCommission: validatorAfter.mevCommissionDec,

--- a/src/commands/analyze-revenue.cmd.ts
+++ b/src/commands/analyze-revenue.cmd.ts
@@ -208,7 +208,8 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
     for (const validatorMeta of pastValidatorCollection.validator_metas) {
       const voteAccount = validatorMeta.vote_account
       const inflationLastEpoch = validatorMeta.commission / 100
-      const mevLastEpoch = validatorMeta.mev_commission ? validatorMeta.mev_commission / 100 : null
+      // mev_commission is validator_commission_bps from Jito TipDistributionAccount
+      const mevLastEpoch = validatorMeta.mev_commission != null ? validatorMeta.mev_commission / 10_000 : null
       commissionMap.set(voteAccount, {
         inflation: inflationLastEpoch,
         mev: mevLastEpoch,
@@ -245,37 +246,41 @@ export class AnalyzeRevenuesCommand extends CommandRunner {
       // if validator increased commission (in comparison to last epoch) AND his auction bid is under the winning PMPE
       // he requires to top up the difference that is not covered by the bid (the part within winning PMPE range is covered by the bid)
       let beforeSamCommissionIncreasePmpe = 0
-      const lastEpochCommissions = pastValidatorCommissions.get(validatorBefore.voteAccount) ?? {
-        inflation: 0,
-        mev: null,
-      }
-      const lastEpochInflationPmpe = rewards.inflationPmpe * (1.0 - lastEpochCommissions.inflation)
-      if (
-        // validatorBefore.revShare.inflationPmpe - inflation at time SAM was run
-        validatorBefore.revShare.inflationPmpe > lastEpochInflationPmpe &&
-        auctionResult.winningTotalPmpe > validatorAfter.revShare.totalPmpe
-      ) {
+      const lastEpochCommissions = pastValidatorCommissions.get(validatorBefore.voteAccount)
+      // without the past snapshot data (--snapshot-past-validators-file-path) nothing is charged
+      if (lastEpochCommissions != null && auctionResult.winningTotalPmpe > validatorAfter.revShare.totalPmpe) {
         const samInflationPmpe = validatorBefore.revShare.inflationPmpe
-        beforeSamCommissionIncreasePmpe = Math.max(0, samInflationPmpe - lastEpochInflationPmpe - samInflationPmpe)
-        this.logger.debug('Validator increased commission and has not won auction', {
-          voteAccount: validatorBefore.voteAccount,
-          inflationCommissionLastEpoch: lastEpochCommissions.inflation,
-          inflationPmpeLastEpoch: lastEpochInflationPmpe,
-          samInflationPmpe: samInflationPmpe,
-          beforeSamCommissionIncreasePmpe: beforeSamCommissionIncreasePmpe,
-          winningPmpe: auctionResult.winningTotalPmpe,
-          validatorTotalPmpe: validatorAfter.revShare.totalPmpe,
-        })
+        const samMevPmpe = validatorBefore.revShare.mevPmpe
+        const lastEpochInflationPmpe = rewards.inflationPmpe * (1.0 - lastEpochCommissions.inflation)
+        const lastEpochMevPmpe =
+          lastEpochCommissions.mev == null ? null : rewards.mevPmpe * (1.0 - lastEpochCommissions.mev)
+        const inflationIncreasePmpe = Math.max(0, lastEpochInflationPmpe - samInflationPmpe)
+        const mevIncreasePmpe = lastEpochMevPmpe == null ? 0 : Math.max(0, lastEpochMevPmpe - samMevPmpe)
+        beforeSamCommissionIncreasePmpe = inflationIncreasePmpe + mevIncreasePmpe
+        if (beforeSamCommissionIncreasePmpe > 0) {
+          this.logger.debug('Validator increased commission before SAM run and has not won auction', {
+            voteAccount: validatorBefore.voteAccount,
+            inflationCommissionLastEpoch: lastEpochCommissions.inflation,
+            mevCommissionLastEpoch: lastEpochCommissions.mev,
+            lastEpochInflationPmpe,
+            lastEpochMevPmpe,
+            samInflationPmpe,
+            samMevPmpe,
+            beforeSamCommissionIncreasePmpe,
+            winningPmpe: auctionResult.winningTotalPmpe,
+            validatorTotalPmpe: validatorAfter.revShare.totalPmpe,
+          })
+        }
       }
 
       evaluation.push({
         voteAccount: validatorBefore.voteAccount,
         expectedInflationCommission: validatorBefore.inflationCommissionDec,
         actualInflationCommission: validatorAfter.inflationCommissionDec,
-        pastInflationCommission: lastEpochCommissions.inflation,
+        pastInflationCommission: lastEpochCommissions?.inflation ?? 0,
         expectedMevCommission: validatorBefore.mevCommissionDec,
         actualMevCommission: validatorAfter.mevCommissionDec,
-        pastMevCommission: lastEpochCommissions.mev,
+        pastMevCommission: lastEpochCommissions?.mev ?? null,
         expectedNonBidPmpe,
         actualNonBidPmpe,
         expectedSamPmpe: expectedNonBidPmpe + validatorBefore.revShare.auctionEffectiveBidPmpe,

--- a/test/analyze-revenue.test.ts
+++ b/test/analyze-revenue.test.ts
@@ -5,6 +5,8 @@ import type { AuctionResult, AuctionValidator, Rewards } from '@marinade.finance
 
 const REWARDS: Rewards = { inflationPmpe: 0.4, mevPmpe: 0.05, blockPmpe: 0 }
 const WINNING_TOTAL_PMPE = 0.45
+// totalPmpe below the winning one: the validator lost the auction at SAM time
+const LOSING_TOTAL_PMPE = WINNING_TOTAL_PMPE - 0.02
 const VOTE_ACCOUNT = 'validator'
 
 const auctionValidator = (inflationPmpe: number, mevPmpe: number, totalPmpe: number): AuctionValidator =>
@@ -51,28 +53,28 @@ describe('analyze-revenues beforeSamCommissionIncreasePmpe', () => {
   it('charges inflation commission increased before the SAM run when auction is lost', () => {
     // last epoch 0% commission, at SAM time 5% (share 0.40 -> 0.38), totalPmpe below winning
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: null }]])
-    const res = evaluate(0.38, 0.05, 0.43, past)
+    const res = evaluate(0.38, 0.05, LOSING_TOTAL_PMPE, past)
     expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02, 12)
   })
 
   it('adds MEV commission increase to the charge', () => {
     // inflation 0% -> 5% and MEV 0% -> 10% (share 0.05 -> 0.045)
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: 0 }]])
-    const res = evaluate(0.38, 0.045, 0.425, past)
+    const res = evaluate(0.38, 0.045, WINNING_TOTAL_PMPE - 0.025, past)
     expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02 + 0.005, 12)
   })
 
   it('nets a MEV commission decrease against an inflation commission increase', () => {
     // inflation 0% -> 5% (share 0.40 -> 0.38) while MEV 10% -> 0% (share 0.045 -> 0.05)
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: 0.1 }]])
-    const res = evaluate(0.38, 0.05, 0.43, past)
+    const res = evaluate(0.38, 0.05, LOSING_TOTAL_PMPE, past)
     expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02 - 0.005, 12)
   })
 
   it('does not charge when a MEV commission decrease outweighs the inflation increase', () => {
     // inflation 5% -> 6% (share 0.38 -> 0.376) while MEV 50% -> 0% (share 0.025 -> 0.05)
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0.05, mev: 0.5 }]])
-    const res = evaluate(0.376, 0.05, 0.43, past)
+    const res = evaluate(0.376, 0.05, LOSING_TOTAL_PMPE, past)
     expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
   })
 
@@ -85,14 +87,14 @@ describe('analyze-revenues beforeSamCommissionIncreasePmpe', () => {
   it('does not charge when commissions did not increase', () => {
     // last epoch 5%, at SAM time 0% (share 0.38 -> 0.40)
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0.05, mev: null }]])
-    const res = evaluate(0.4, 0.05, 0.43, past)
+    const res = evaluate(0.4, 0.05, LOSING_TOTAL_PMPE, past)
     expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
   })
 
   it('charges when auction was lost at SAM time even if pmpe rose after the SAM run', () => {
-    // lost at SAM time (0.43 < 0.45), commission decreased after so the after-state would look like a win
+    // lost at SAM time, commission decreased after so the after-state would look like a win
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: null }]])
-    const before = auctionValidator(0.38, 0.05, 0.43)
+    const before = auctionValidator(0.38, 0.05, LOSING_TOTAL_PMPE)
     const after = auctionValidator(0.4, 0.05, WINNING_TOTAL_PMPE)
     const result = cmd.evaluateRevenueExpectationForAuctionValidators([before], [after], auctionResult, past, REWARDS)
     expect(result[0]?.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02, 12)
@@ -102,13 +104,13 @@ describe('analyze-revenues beforeSamCommissionIncreasePmpe', () => {
     // won at SAM time thanks to the bid, commission increased after so the after-state would look like a loss
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: null }]])
     const before = auctionValidator(0.38, 0.05, WINNING_TOTAL_PMPE)
-    const after = auctionValidator(0.36, 0.05, 0.41)
+    const after = auctionValidator(0.36, 0.05, WINNING_TOTAL_PMPE - 0.04)
     const result = cmd.evaluateRevenueExpectationForAuctionValidators([before], [after], auctionResult, past, REWARDS)
     expect(result[0]?.beforeSamCommissionIncreasePmpe).toBe(0)
   })
 
   it('does not charge without past snapshot data', () => {
-    const res = evaluate(0.38, 0.045, 0.43, new Map())
+    const res = evaluate(0.38, 0.045, LOSING_TOTAL_PMPE, new Map())
     expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
     expect(res.pastInflationCommission).toBe(0)
     expect(res.pastMevCommission).toBeNull()

--- a/test/analyze-revenue.test.ts
+++ b/test/analyze-revenue.test.ts
@@ -11,7 +11,7 @@ const auctionValidator = (inflationPmpe: number, mevPmpe: number, totalPmpe: num
   ({
     voteAccount: VOTE_ACCOUNT,
     inflationCommissionDec: 1 - inflationPmpe / REWARDS.inflationPmpe,
-    mevCommissionDec: null,
+    mevCommissionDec: 1 - mevPmpe / REWARDS.mevPmpe,
     maxStakeWanted: null,
     revShare: {
       inflationPmpe,
@@ -62,6 +62,20 @@ describe('analyze-revenues beforeSamCommissionIncreasePmpe', () => {
     expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02 + 0.005, 12)
   })
 
+  it('nets a MEV commission decrease against an inflation commission increase', () => {
+    // inflation 0% -> 5% (share 0.40 -> 0.38) while MEV 10% -> 0% (share 0.045 -> 0.05)
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: 0.1 }]])
+    const res = evaluate(0.38, 0.05, 0.43, past)
+    expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02 - 0.005, 12)
+  })
+
+  it('does not charge when a MEV commission decrease outweighs the inflation increase', () => {
+    // inflation 5% -> 6% (share 0.38 -> 0.376) while MEV 50% -> 0% (share 0.025 -> 0.05)
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0.05, mev: 0.5 }]])
+    const res = evaluate(0.376, 0.05, 0.43, past)
+    expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
+  })
+
   it('does not charge a validator who won the auction', () => {
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: 0 }]])
     const res = evaluate(0.38, 0.045, WINNING_TOTAL_PMPE, past)
@@ -73,6 +87,24 @@ describe('analyze-revenues beforeSamCommissionIncreasePmpe', () => {
     const past = new Map([[VOTE_ACCOUNT, { inflation: 0.05, mev: null }]])
     const res = evaluate(0.4, 0.05, 0.43, past)
     expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
+  })
+
+  it('charges when auction was lost at SAM time even if pmpe rose after the SAM run', () => {
+    // lost at SAM time (0.43 < 0.45), commission decreased after so the after-state would look like a win
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: null }]])
+    const before = auctionValidator(0.38, 0.05, 0.43)
+    const after = auctionValidator(0.4, 0.05, WINNING_TOTAL_PMPE)
+    const result = cmd.evaluateRevenueExpectationForAuctionValidators([before], [after], auctionResult, past, REWARDS)
+    expect(result[0]?.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02, 12)
+  })
+
+  it('does not charge when auction was won at SAM time even if pmpe dropped after the SAM run', () => {
+    // won at SAM time thanks to the bid, commission increased after so the after-state would look like a loss
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: null }]])
+    const before = auctionValidator(0.38, 0.05, WINNING_TOTAL_PMPE)
+    const after = auctionValidator(0.36, 0.05, 0.41)
+    const result = cmd.evaluateRevenueExpectationForAuctionValidators([before], [after], auctionResult, past, REWARDS)
+    expect(result[0]?.beforeSamCommissionIncreasePmpe).toBe(0)
   })
 
   it('does not charge without past snapshot data', () => {

--- a/test/analyze-revenue.test.ts
+++ b/test/analyze-revenue.test.ts
@@ -1,0 +1,107 @@
+import { AnalyzeRevenuesCommand } from '../src/commands/analyze-revenue.cmd'
+
+import type { SnapshotValidatorsCollection } from '../src/commands/analyze-revenue.cmd'
+import type { AuctionResult, AuctionValidator, Rewards } from '@marinade.finance/ds-sam-sdk'
+
+const REWARDS: Rewards = { inflationPmpe: 0.4, mevPmpe: 0.05, blockPmpe: 0 }
+const WINNING_TOTAL_PMPE = 0.45
+const VOTE_ACCOUNT = 'validator'
+
+const auctionValidator = (inflationPmpe: number, mevPmpe: number, totalPmpe: number): AuctionValidator =>
+  ({
+    voteAccount: VOTE_ACCOUNT,
+    inflationCommissionDec: 1 - inflationPmpe / REWARDS.inflationPmpe,
+    mevCommissionDec: null,
+    maxStakeWanted: null,
+    revShare: {
+      inflationPmpe,
+      mevPmpe,
+      totalPmpe,
+      auctionEffectiveBidPmpe: 0,
+    },
+  }) as unknown as AuctionValidator
+
+const auctionResult = { winningTotalPmpe: WINNING_TOTAL_PMPE } as AuctionResult
+
+describe('analyze-revenues beforeSamCommissionIncreasePmpe', () => {
+  const cmd = new AnalyzeRevenuesCommand()
+
+  const evaluate = (
+    samInflationPmpe: number,
+    samMevPmpe: number,
+    totalPmpe: number,
+    pastCommissions: Map<string, { inflation: number; mev: number | null }>,
+  ) => {
+    const validator = auctionValidator(samInflationPmpe, samMevPmpe, totalPmpe)
+    const result = cmd.evaluateRevenueExpectationForAuctionValidators(
+      [validator],
+      [validator],
+      auctionResult,
+      pastCommissions,
+      REWARDS,
+    )
+    expect(result).toHaveLength(1)
+    const evaluation = result[0]
+    if (evaluation == null) {
+      throw new Error('Missing revenue expectation evaluation')
+    }
+    return evaluation
+  }
+
+  it('charges inflation commission increased before the SAM run when auction is lost', () => {
+    // last epoch 0% commission, at SAM time 5% (share 0.40 -> 0.38), totalPmpe below winning
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: null }]])
+    const res = evaluate(0.38, 0.05, 0.43, past)
+    expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02, 12)
+  })
+
+  it('adds MEV commission increase to the charge', () => {
+    // inflation 0% -> 5% and MEV 0% -> 10% (share 0.05 -> 0.045)
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: 0 }]])
+    const res = evaluate(0.38, 0.045, 0.425, past)
+    expect(res.beforeSamCommissionIncreasePmpe).toBeCloseTo(0.02 + 0.005, 12)
+  })
+
+  it('does not charge a validator who won the auction', () => {
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0, mev: 0 }]])
+    const res = evaluate(0.38, 0.045, WINNING_TOTAL_PMPE, past)
+    expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
+  })
+
+  it('does not charge when commissions did not increase', () => {
+    // last epoch 5%, at SAM time 0% (share 0.38 -> 0.40)
+    const past = new Map([[VOTE_ACCOUNT, { inflation: 0.05, mev: null }]])
+    const res = evaluate(0.4, 0.05, 0.43, past)
+    expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
+  })
+
+  it('does not charge without past snapshot data', () => {
+    const res = evaluate(0.38, 0.045, 0.43, new Map())
+    expect(res.beforeSamCommissionIncreasePmpe).toBe(0)
+    expect(res.pastInflationCommission).toBe(0)
+    expect(res.pastMevCommission).toBeNull()
+  })
+})
+
+describe('analyze-revenues getPastValidatorCommissions', () => {
+  const cmd = new AnalyzeRevenuesCommand()
+
+  it('parses commissions with mev_commission in bps', () => {
+    const collection = {
+      epoch: 100,
+      validator_metas: [
+        { vote_account: 'a', commission: 5, mev_commission: 500, stake: 0, credits: 0 },
+        { vote_account: 'b', commission: 100, mev_commission: 0, stake: 0, credits: 0 },
+        { vote_account: 'c', commission: 0, stake: 0, credits: 0 },
+      ],
+    } as SnapshotValidatorsCollection
+    const map = cmd.getPastValidatorCommissions(collection)
+    expect(map.get('a')).toEqual({ inflation: 0.05, mev: 0.05 })
+    expect(map.get('b')).toEqual({ inflation: 1, mev: 0 })
+    expect(map.get('c')).toEqual({ inflation: 0, mev: null })
+  })
+
+  it('returns empty map without past collection', () => {
+    expect(cmd.getPastValidatorCommissions(null).size).toBe(0)
+  })
+})


### PR DESCRIPTION
On investigating the dynamic bid commission charge, I found two issues in the processing. One is here: an incorrect condition for charging inflation commission changes within an epoch. When this handling was added, we intentionally omitted MEV because it was not reliable at the time (2024). Since then, Jito MEV has become quite stable, and I believe we should have enabled mid-epoch MEV charging much earlier.

https://github.com/marinade-finance/validator-bonds/pull/442
