### PR TITLE
[version] bump for 0.1.1 as 0.1.0 was wrongly published [trivial]

### DIFF
--- a/packages/ds-sam-calc/package.json
+++ b/packages/ds-sam-calc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-calc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",


### PR DESCRIPTION
I wrongly published version 0.1.0 to the npm registry - this seems to be caused by a pnpm bug and wrong use of `npm` calls

```
  - pnpm #11098 — can't publish to npm registry org, PUT 404 (open; v11 didn't fix)
  - pnpm #10926 — 10.31.0 breaks publish (fixed in 10.32.0)
  - pnpm #11513 — OIDC trusted publishing fails on pnpm 11
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package releases to version 0.1.1.
  * No functional changes included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->