### PR TITLE
[ds-sam-calc] Bond-capped winners: advise bond top-up, not "raise bid"

### DIFF
--- a/packages/ds-sam-calc/src/tip-engine.ts
+++ b/packages/ds-sam-calc/src/tip-engine.ts
@@ -196,8 +196,12 @@ function tip(
   chip?: string,
 ): ValidatorTip {
   const built: ValidatorTip = { text, urgency, constraint, delta }
-  if (alert) built.alert = true
-  if (chip != null) built.chip = chip
+  if (alert) {
+    built.alert = true
+  }
+  if (chip != null) {
+    built.chip = chip
+  }
   return built
 }
 
@@ -274,11 +278,10 @@ function bondCta(
   // 'watch' implies runway > minBondEpochs + BOND_URGENT_EPOCHS, so any 'watch'
   // validator is already above the fee threshold.
   const fires = health === 'critical' || (inSet && health === 'watch' && (coverage.topUpToKeepStake > 0 || delta <= 0))
-  // Bond runway looks fine — but "fine" is measured against a target the bond
-  // itself has already clamped down. If that target is pinned at the bond
-  // ceiling below the validator's maxStakeWanted, the bond is still the growth
-  // lever (see bondGrowthCta); otherwise there's nothing to say on this lever.
-  if (!fires) return inSet ? bondGrowthCta(validator, dsSamConfig.minMaxStakeWanted, delta) : null
+  // Healthy runway is measured against an already bond-clamped target, so a bond-capped winner can still need a top-up — defer to bondGrowthCta.
+  if (!fires) {
+    return inSet ? bondGrowthCta(validator, dsSamConfig.minMaxStakeWanted, delta) : null
+  }
   // WATCH + no keep-shortfall + defending: the "grow stake" advisory fires at
   // INFO, which selectTip ranks below deltaCta's WARNING. Escalate to WARNING
   // so the actionable bond advice beats the symptom message.
@@ -377,21 +380,7 @@ function isDefending(validator: AugmentedAuctionValidator, delta: number): boole
   return (validator.marinadeActivatedStakeSol ?? 0) > NON_TRIVIAL_STAKE_SOL && delta < -NON_TRIVIAL_LOSS_SOL
 }
 
-// The BOND — not the bid — is the growth lever when the auction has clipped the
-// validator's SAM target to the bond-supported ceiling while they want more
-// stake than that ceiling backs. maxBondDelegation = min(bondSamStakeCapSol,
-// per-validator TVL cap); the bond is the binding half ONLY when the bond cap
-// is the smaller term (bondSamStakeCapSol <= maxBondDelegation). When the TVL
-// cap binds instead it's the per-validator cap (not something a top-up fixes);
-// when maxStakeWanted binds the validator is already at their own setting.
-// Topping up the bond lifts the ceiling toward maxStakeWanted; raising the bid
-// does nothing for a bond-capped winner.
-//
-// Returns the bond-lever CTA for this case, or null when the bond is not what's
-// capping growth. Emitted from bondCta's healthy/non-firing path so a bond-
-// capped winner gets constraint:'bond' + info, which beats deltaCta's
-// "Raise bid to grow stake" (rank/info) on the LEVER_ORDER tiebreak. Callers
-// gate on inSet — an out-of-set bid is the bid's problem, owned by bidCta.
+// Bond (not bid) is the growth lever when the auction clamps an in-set winner's target to the bond ceiling below their maxStakeWanted; runs from bondCta's healthy path so its 'bond'/info CTA outranks deltaCta's "raise bid" on the LEVER_ORDER tiebreak.
 function bondGrowthCta(
   validator: AugmentedAuctionValidator,
   minMaxStakeWanted: number | null,
@@ -400,18 +389,23 @@ function bondGrowthCta(
   const target = validator.auctionStake.marinadeSamTargetSol
   const maxBond = validator.maxBondDelegation
   const bondCap = validator.bondSamStakeCapSol
-  // Target must sit at the ceiling (within 1%), the ceiling must be the BOND
-  // cap (not the per-validator TVL cap), and the validator must want more than
-  // the bond currently backs. A null maxStakeWanted means no self-imposed
-  // ceiling (takes as much as it can); a positive one is floored by
-  // minMaxStakeWanted (SDK raises sub-floor requests), matching deltaCta.
-  if (!(target > 0) || !Number.isFinite(maxBond) || maxBond <= 0) return null
-  if (target < maxBond * 0.99) return null
-  if (!Number.isFinite(bondCap) || bondCap > maxBond + 1e-6) return null
+  // Fire only when the bond cap — not the TVL cap or maxStakeWanted — is what holds target below what the validator wants.
+  if (!(target > 0) || !Number.isFinite(maxBond) || maxBond <= 0) {
+    return null
+  }
+  if (target < maxBond * 0.99) {
+    return null
+  }
+  if (!Number.isFinite(bondCap) || bondCap > maxBond + 1e-6) {
+    return null
+  }
   const wanted = validator.maxStakeWanted
+  // null maxStakeWanted = no self-imposed ceiling (treated as +Infinity); a set one is floored by minMaxStakeWanted, matching deltaCta.
   const wantedCeiling =
     wanted != null && wanted > 0 ? Math.max(minMaxStakeWanted ?? 0, wanted) : Number.POSITIVE_INFINITY
-  if (wantedCeiling <= maxBond + 1e-6) return null
+  if (wantedCeiling <= maxBond + 1e-6) {
+    return null
+  }
   return tip(
     wanted != null && wanted > 0 ? 'Top up bond to reach your `maxStakeWanted`.' : 'Top up bond to grow stake.',
     'info',
@@ -442,9 +436,13 @@ function outOfSetCta(
   delta: number,
   blacklist?: Set<string>,
 ): ValidatorTip | null {
-  if (selectInSet(validator)) return null
+  if (selectInSet(validator)) {
+    return null
+  }
   // Bid actually is the lever to pull → let bidCta own the message.
-  if (validator.revShare.totalPmpe < winningTotalPmpe) return null
+  if (validator.revShare.totalPmpe < winningTotalPmpe) {
+    return null
+  }
 
   // Severity ladder, applied throughout this function:
   //   red    — a real penalty is charged this epoch. Set tip.alert so the
@@ -510,7 +508,9 @@ function capCta(validator: AugmentedAuctionValidator, delta: number): ValidatorT
   // Fire for delta <= 0: losing stake (delta < 0) or blocked from growing
   // (delta === 0) by a binding cap. Skip when delta > 0 — stake is arriving,
   // cap is not the constraint this epoch.
-  if (delta > 0 || cap == null || cap.totalLeftToCapSol !== 0) return null
+  if (delta > 0 || cap == null || cap.totalLeftToCapSol !== 0) {
+    return null
+  }
   // Severity follows the global ladder:
   //   grey   — WANT cap (user-set).
   //   yellow — other cap AND defending (meaningful stake leaving).

--- a/packages/ds-sam-calc/src/tip-engine.ts
+++ b/packages/ds-sam-calc/src/tip-engine.ts
@@ -274,7 +274,11 @@ function bondCta(
   // 'watch' implies runway > minBondEpochs + BOND_URGENT_EPOCHS, so any 'watch'
   // validator is already above the fee threshold.
   const fires = health === 'critical' || (inSet && health === 'watch' && (coverage.topUpToKeepStake > 0 || delta <= 0))
-  if (!fires) return null
+  // Bond runway looks fine — but "fine" is measured against a target the bond
+  // itself has already clamped down. If that target is pinned at the bond
+  // ceiling below the validator's maxStakeWanted, the bond is still the growth
+  // lever (see bondGrowthCta); otherwise there's nothing to say on this lever.
+  if (!fires) return inSet ? bondGrowthCta(validator, dsSamConfig.minMaxStakeWanted, delta) : null
   // WATCH + no keep-shortfall + defending: the "grow stake" advisory fires at
   // INFO, which selectTip ranks below deltaCta's WARNING. Escalate to WARNING
   // so the actionable bond advice beats the symptom message.
@@ -371,6 +375,49 @@ function capCauseLine(type: AuctionConstraintType | undefined, name: string | un
 // vs INFO/NEUTRAL don't drift apart.
 function isDefending(validator: AugmentedAuctionValidator, delta: number): boolean {
   return (validator.marinadeActivatedStakeSol ?? 0) > NON_TRIVIAL_STAKE_SOL && delta < -NON_TRIVIAL_LOSS_SOL
+}
+
+// The BOND — not the bid — is the growth lever when the auction has clipped the
+// validator's SAM target to the bond-supported ceiling while they want more
+// stake than that ceiling backs. maxBondDelegation = min(bondSamStakeCapSol,
+// per-validator TVL cap); the bond is the binding half ONLY when the bond cap
+// is the smaller term (bondSamStakeCapSol <= maxBondDelegation). When the TVL
+// cap binds instead it's the per-validator cap (not something a top-up fixes);
+// when maxStakeWanted binds the validator is already at their own setting.
+// Topping up the bond lifts the ceiling toward maxStakeWanted; raising the bid
+// does nothing for a bond-capped winner.
+//
+// Returns the bond-lever CTA for this case, or null when the bond is not what's
+// capping growth. Emitted from bondCta's healthy/non-firing path so a bond-
+// capped winner gets constraint:'bond' + info, which beats deltaCta's
+// "Raise bid to grow stake" (rank/info) on the LEVER_ORDER tiebreak. Callers
+// gate on inSet — an out-of-set bid is the bid's problem, owned by bidCta.
+function bondGrowthCta(
+  validator: AugmentedAuctionValidator,
+  minMaxStakeWanted: number | null,
+  delta: number,
+): ValidatorTip | null {
+  const target = validator.auctionStake.marinadeSamTargetSol
+  const maxBond = validator.maxBondDelegation
+  const bondCap = validator.bondSamStakeCapSol
+  // Target must sit at the ceiling (within 1%), the ceiling must be the BOND
+  // cap (not the per-validator TVL cap), and the validator must want more than
+  // the bond currently backs. A null maxStakeWanted means no self-imposed
+  // ceiling (takes as much as it can); a positive one is floored by
+  // minMaxStakeWanted (SDK raises sub-floor requests), matching deltaCta.
+  if (!(target > 0) || !Number.isFinite(maxBond) || maxBond <= 0) return null
+  if (target < maxBond * 0.99) return null
+  if (!Number.isFinite(bondCap) || bondCap > maxBond + 1e-6) return null
+  const wanted = validator.maxStakeWanted
+  const wantedCeiling =
+    wanted != null && wanted > 0 ? Math.max(minMaxStakeWanted ?? 0, wanted) : Number.POSITIVE_INFINITY
+  if (wantedCeiling <= maxBond + 1e-6) return null
+  return tip(
+    wanted != null && wanted > 0 ? 'Top up bond to reach your `maxStakeWanted`.' : 'Top up bond to grow stake.',
+    'info',
+    'bond',
+    delta,
+  )
 }
 
 // Out-of-set despite a high enough totalPmpe. The bid isn't the lever —

--- a/packages/ds-sam-calc/test/tip-engine.test.ts
+++ b/packages/ds-sam-calc/test/tip-engine.test.ts
@@ -210,6 +210,64 @@ describe('getValidatorTip', () => {
     expect(tip.text).toBe('Raise bid to grow stake next epoch.')
   })
 
+  it('in-set, target pinned at bond ceiling below maxStakeWanted → info/bond "top up to reach maxStakeWanted" (NOT raise bid)', () => {
+    // Regression: a winning validator whose SAM target is clipped by the bond
+    // (maxBondDelegation, set by the bond cap not the TVL cap) below their
+    // maxStakeWanted. The bond runway is healthy for the clamped target, so
+    // bondCta used to return null and deltaCta wrongly advised "Raise bid to
+    // grow stake" — a higher bid can't lift a bond ceiling; a bond top-up can.
+    const validator = makeValidator({
+      bondGoodForNEpochs: 20, // healthy runway for the current (clamped) target
+      maxStakeWanted: 200_000,
+      maxBondDelegation: 100_000, // ceiling the auction pinned the target to
+      bondSamStakeCapSol: 100_000, // bond cap == ceiling → bond is the binder
+      auctionStake: { marinadeSamTargetSol: 100_000 },
+      marinadeActivatedStakeSol: 50_000, // below target → would be RAISE_TO_GROW
+      values: { expectedStakeChangeSol: 0 },
+    })
+    // priorityFrontierPmpe 50 > totalPmpe 28 → without the fix this is the
+    // "Raise bid to grow stake next epoch." branch.
+    const tip = getValidatorTip(validator, DS_SAM_CONFIG, 20, undefined, undefined, 50)
+    expect(tip.constraint).toBe('bond')
+    expect(tip.urgency).toBe('info')
+    expect(tip.text).toBe('Top up bond to reach your `maxStakeWanted`.')
+    expect(tip.text).not.toBe('Raise bid to grow stake next epoch.')
+  })
+
+  it('in-set, target at ceiling but TVL cap (not bond) is the binder → stays raise-bid, no bond CTA', () => {
+    // maxBondDelegation is set by the per-validator TVL cap here
+    // (bondSamStakeCapSol > maxBondDelegation), so a bond top-up would NOT
+    // grow stake — the growth CTA must not fire.
+    const validator = makeValidator({
+      bondGoodForNEpochs: 20,
+      maxStakeWanted: 200_000,
+      maxBondDelegation: 100_000,
+      bondSamStakeCapSol: 150_000, // bond cap ABOVE the ceiling → TVL cap binds
+      auctionStake: { marinadeSamTargetSol: 100_000 },
+      marinadeActivatedStakeSol: 50_000,
+      values: { expectedStakeChangeSol: 0 },
+    })
+    const tip = getValidatorTip(validator, DS_SAM_CONFIG, 20, undefined, undefined, 50)
+    expect(tip.constraint).not.toBe('bond')
+    expect(tip.text).toBe('Raise bid to grow stake next epoch.')
+  })
+
+  it('in-set, target at bond ceiling that equals maxStakeWanted → at own cap, no bond CTA', () => {
+    // Bond ceiling coincides with maxStakeWanted → the validator is at their
+    // own setting; topping up the bond wouldn't grow them, so no bond CTA.
+    const validator = makeValidator({
+      bondGoodForNEpochs: 20,
+      maxStakeWanted: 100_000,
+      maxBondDelegation: 100_000,
+      bondSamStakeCapSol: 100_000,
+      auctionStake: { marinadeSamTargetSol: 100_000 },
+      marinadeActivatedStakeSol: 100_000,
+      values: { expectedStakeChangeSol: 0 },
+    })
+    const tip = getValidatorTip(validator, DS_SAM_CONFIG, 20, undefined, undefined, 50)
+    expect(tip.constraint).not.toBe('bond')
+  })
+
   it('delta < 0 + at own maxStakeWanted cap (SUP-188 rebalance down) → neutral "At your maxStakeWanted setting"', () => {
     const config = { ...DS_SAM_CONFIG, minMaxStakeWanted: 10_000 } as unknown as DsSamConfig
     const validator = makeValidator({


### PR DESCRIPTION
## Problem

On the PSR dashboard, a **winning** validator whose SAM stake is capped by its **bond** — not its bid — is told to **"Raise bid to grow stake next epoch."** Raising the bid can't help: the target is pinned at the bond ceiling, so the only lever that grows their stake is a **bond top-up**.

Reported by Cerba on `psr.marinade.finance`. The Next Step / tip text is produced by `getValidatorTip` in this package (`@marinade.finance/ds-sam-calc`), which the dashboard re-exports — so the fix belongs here, not in psr-dashboard.

**Reproduces on (epoch 1003):**
- `5cwxevV9u1poNgfc1tKxMfEGX4oKt1DZNSHg48Umubm3` (bidding ~7.60% APY, already winning)
- `3jkJVgfz1zrHSy6YLK6g96eTj49kCnDj2i8AbbKLZhkk`
- `9FZWpUMfXZ3993g2BfqSFg7xcx9iUCxQwKeYzr2WQCM1`

For the first, simulating ~135 SOL added to the bond lifts `marinadeSamTargetSol` up to `maxStakeWanted` — confirming the bond is the binding constraint.

## Root cause

`bondCta` only fires when bond **health** (runway) is `critical`/`watch`. But runway is measured against the target the bond has **already clamped down** — so a bond that caps growth still looks "healthy," `bondCta` returns `null`, and the tip falls through to `deltaCta`, whose trajectory fallback emits `RAISE_TO_GROW` ("Raise bid to grow stake next epoch.") for any in-set validator below the priority frontier. That misattributes the growth lever to the bid.

## Fix

Add `bondGrowthCta`, returned from `bondCta`'s healthy/non-firing path for an **in-set** validator whose target sits at the **bond-supported** ceiling below their wanted stake:

> **Top up bond to reach your `maxStakeWanted`.**  _(constraint: `bond`, urgency: `info`)_

It outranks `deltaCta`'s `RAISE_TO_GROW` (`rank`/`info`) on the `LEVER_ORDER` tiebreak, so the actionable lever wins. It fires **only** when the BOND is the binding half of `maxBondDelegation` (`min(bondSamStakeCapSol, per-validator TVL cap)`), i.e. `bondSamStakeCapSol <= maxBondDelegation`:
- **TVL cap** binds instead → left to the existing per-validator cap CTA (a top-up wouldn't help).
- **maxStakeWanted** binds → the existing `At your `maxStakeWanted` setting` CTA already covers it.
- bond below-min / unhealthy runway → unchanged (higher-severity CTAs still win).
- `maxStakeWanted` null → treated as "no self-imposed ceiling" and worded "Top up bond to grow stake."

## Tests

`packages/ds-sam-calc/test/tip-engine.test.ts` — 3 new cases:
1. bond ceiling below `maxStakeWanted` → `bond`/`info` "reach your `maxStakeWanted`" (was `RAISE_TO_GROW`)
2. TVL cap is the binder (`bondSamStakeCapSol > maxBondDelegation`) → stays "raise bid", no bond CTA
3. bond ceiling == `maxStakeWanted` → at own cap, no bond CTA

Full `ds-sam-calc` suite green (78 passed); `tsc --build` and prettier clean; no new eslint complexity warning.

## Notes for reviewers
- **Precedence:** this bond `info` CTA also wins over `deltaCta`'s positive "N SOL arriving next epoch" while a bond-capped validator is still filling toward its ceiling. That seems right (top-up is the actionable next step), but flagging in case you'd rather defer it while stake is actively arriving, as the watch-tier CTAs do.
- The CTA text is figure-free (unlike the other `Top up …` strings, which carry a SOL amount). Computing the exact top-up to lift the ceiling to `maxStakeWanted` means inverting `bondStakeCapSam`; happy to add it if you want the amount inline.
- Needs a `ds-sam-calc` version bump + republish for psr-dashboard to pick it up (currently pinned to `0.1.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-set validator guidance when bond limits clamp the effective SAM target.
  * Added bond-specific advisory CTAs when the validator can’t reach their `maxStakeWanted` due to the bond cap; avoids suggesting bond top-ups when TVL limits or the validator’s own maximum are the real constraint.
  * Updated messaging so the next step is correctly shown as bond top-up vs “raise bid” depending on which cap applies.
* **Tests**
  * Extended regression coverage for in-set “bond top-up vs raise-bid” scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->