### PR TITLE
[readme] adding npm badge for calc [trivial]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Marinade's Stake Auction for Solana validators.
 
-<a href="https://www.npmjs.com/package/@marinade.finance/ds-sam-sdk">
-  <img src="https://img.shields.io/npm/v/%40marinade.finance%2Fds-sam-sdk?logo=npm&color=377CC0" />
-</a>
+|Package       | NPM registry |
+| -------------| ------------ |
+| ds-sam-sdk   | <a href="https://www.npmjs.com/package/@marinade.finance/ds-sam-sdk"><img src="https://img.shields.io/npm/v/%40marinade.finance%2Fds-sam-sdk?logo=npm&color=377CC0" /></a> |
+| ds-sam-calc  | <a href="https://www.npmjs.com/package/@marinade.finance/ds-sam-calc"><img src="https://img.shields.io/npm/v/%40marinade.finance%2Fds-sam-calc?logo=npm&color=377CC0" /></a> |
 
 Validators bid PMPE (per mille per epoch) to receive Marinade
 stake. Allocation proceeds highest to lowest PMPE until stake


### PR DESCRIPTION
Updating readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to display npm registry badges for both `ds-sam-sdk` and `ds-sam-calc`.
  * Replaced the previous single-package badge with a clearer package comparison table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->