### PR TITLE
[GEN-8377] Raise validator client version floor to current Agave/Frankendancer

### DIFF
--- a/packages/ds-sam-calc/src/config.ts
+++ b/packages/ds-sam-calc/src/config.ts
@@ -142,7 +142,7 @@ export const DEFAULT_CONFIG: DsSamConfig = {
   rewardsEpochsCount: 10,
   validatorsUptimeEpochsCount: 3,
   validatorsUptimeThresholdDec: 0.8,
-  validatorsClientVersionSemverExpr: '>=1.18.15 || >=0.101.20013 <1.0.0',
+  validatorsClientVersionSemverExpr: '>=4.1.0-beta.0 || >=0.1004.0-rc.40101 <1.0.0',
   validatorsMaxEffectiveCommissionDec: 0.07,
   unprotectedDelegatedStakeDec: 0,
   unprotectedFoundationStakeDec: 0,

--- a/packages/ds-sam-sdk/test/eligibility.test.ts
+++ b/packages/ds-sam-sdk/test/eligibility.test.ts
@@ -54,121 +54,48 @@ describe('eligibility', () => {
     expect(findValidatorInResult(eligibleValidator.voteAccount, result)?.samEligible).toStrictEqual(true)
   })
 
-  it('considers also FD versions eligible', async () => {
+  it('enforces the client version floor across Agave and Frankendancer', async () => {
     const voteAccounts = generateVoteAccounts()
     const identities = generateIdentities()
 
-    const validators: [ValidatorMockBuilder, boolean][] = [
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.18.15'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.18.16'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.18.14'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.17.99'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.19.0'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.113.20007'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.101.20013'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.101.20014'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.101.20012'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.102.0'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.100.99'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('0.999.99'),
-        true,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.0.0'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.0.1'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('1.1.0'),
-        false,
-      ],
-      [
-        new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
-          .withEligibleDefaults()
-          .withVersion('2.0.0'),
-        true,
-      ],
+    const cases: [string, boolean][] = [
+      // Agave / Jito lane (floor 4.1.0-beta.0)
+      ['1.18.15', false],
+      ['3.9.9', false],
+      ['4.0.3', false],
+      ['4.1.0-alpha.0', false],
+      ['4.1.0-beta.0', true],
+      ['4.1.0-rc.1', true],
+      ['4.1.0', true],
+      ['4.1.1', true],
+      ['5.0.0', true],
+      // reserved for full Firedancer (1.x), currently rejected
+      ['1.0.0', false],
+      ['1.1.0', false],
+      // Frankendancer lane (floor 0.1004.0-rc.40101, < 1.0.0)
+      ['0.1.1', false],
+      ['0.101.20013', false],
+      ['0.911.40002', false],
+      ['0.1004.0-rc.40100', false],
+      ['0.1004.0-rc.40101', true],
+      ['0.1004.0', true],
+      ['0.1005.40100', true],
     ]
-    const dsSam = new DsSamSDK(
-      {
-        validatorsClientVersionSemverExpr: '>=1.18.15 || >=0.101.20013 <1.0.0',
-      },
-      defaultStaticDataProviderBuilder(validators.map(([validator]) => validator)),
-    )
+
+    const validators = cases.map(([version, eligible]) => ({
+      version,
+      eligible,
+      builder: new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
+        .withEligibleDefaults()
+        .withVersion(version),
+    }))
+    // Default config floor tested, no overrides; expected values track config.ts.
+    const dsSam = new DsSamSDK({}, defaultStaticDataProviderBuilder(validators.map(v => v.builder)))
     const result = await dsSam.run()
 
-    validators.forEach(([validator, eligibility]) => {
-      const v = findValidatorInResult(validator.voteAccount, result)
-      expect(v).toBeDefined()
-      expect(v?.samEligible).toStrictEqual(eligibility)
-    })
+    const actual = validators.map(v => [v.version, findValidatorInResult(v.builder.voteAccount, result)?.samEligible])
+    const expected = validators.map(v => [v.version, v.eligible])
+    expect(actual).toStrictEqual(expected)
   })
 
   it('marks empty epochStats as ineligible', async () => {

--- a/packages/ds-sam-sdk/test/helpers/validator-mock-builder.ts
+++ b/packages/ds-sam-sdk/test/helpers/validator-mock-builder.ts
@@ -28,7 +28,7 @@ export class ValidatorMockBuilder {
   private nativeStake = 0
   private liquidStake = 0
   private externalStake = 0
-  private version = '1.18.15'
+  private version = '4.1.0'
   private bond: BondDataType | null = null
   private country: string | null = null
   private aso: string | null = null

--- a/packages/ds-sam-sdk/test/sam.test.ts
+++ b/packages/ds-sam-sdk/test/sam.test.ts
@@ -533,14 +533,14 @@ describe('sam', () => {
     }
 
     it('accepts in-range stable Firedancer version', async () => {
-      expect(await isEligible('0.909.0')).toBe(true)
+      expect(await isEligible('0.1005.40100')).toBe(true)
     })
 
-    // Regression: validators-API reports harmonic FD as 0.909.0-rc.40001.
+    // Regression: Frankendancer mainnet releases are prereleases (e.g. 0.1004.0-rc.40101).
     // node-semver excludes prereleases from ranges by default; SDK passes
-    // { includePrerelease: true } so this version is treated as in-range.
-    it('accepts in-range Firedancer prerelease (harmonic FD)', async () => {
-      expect(await isEligible('0.909.0-rc.40001')).toBe(true)
+    // { includePrerelease: true } so in-range FD prereleases stay eligible.
+    it('accepts in-range Firedancer prerelease', async () => {
+      expect(await isEligible('0.1004.0-rc.40101')).toBe(true)
     })
 
     it('rejects out-of-range version', async () => {


### PR DESCRIPTION
Raises the default `validatorsClientVersionSemverExpr` floor to match Anza's current mainnet-beta [Version Floor](https://github.com/anza-xyz/agave/wiki/Feature-Gate-Tracker-Schedule).

### Config
`>=1.18.15 || >=0.101.20013 <1.0.0` → `>=4.1.0-beta.0 || >=0.1004.0-rc.40101 <1.0.0`

- **Agave / Jito** floor: `4.1.0-beta.0`
- **Frankendancer** floor: `0.1004.0-rc.40101` (`< 1.0.0` keeps the `1.x` lane reserved for full Firedancer, which is not yet on mainnet)

### Tests
- `eligibility.test.ts` — the version-gate test now exercises the **default config** floor across Agave and Frankendancer boundaries: prerelease ordering (`alpha < beta < rc`), the rc build-number cutoff, the `1.x`–`3.x` dead zone, and the dev/anomaly cohort.
- `sam.test.ts` — updated the two `client version gate` cases to current in-range versions.
- `validator-mock-builder.ts` — default mock version `1.18.15` → `4.1.0` so default mocks stay eligible under the new floor.

Full suite green (248/248).

Companion change bumping the pipeline's `auction-config.json` to the same floor: [marinade-finance/ds-sam-pipeline#457](https://github.com/marinade-finance/ds-sam-pipeline/pull/457).

## Summary by CodeRabbit

- **New Features**
  - Updated validator client version eligibility rules to recognize current Agave and Frankendancer releases.
  - Added support for the latest eligible Firedancer stable and prerelease versions.
  - Refined version boundaries to reject reserved or unsupported release ranges.

- **Bug Fixes**
  - Corrected prerelease version handling so eligible prerelease clients are evaluated consistently.
  - Updated default eligibility behavior to reflect the current client version floor.