### PR TITLE
[GEN-8704][auction] fix cap-blocked PMPE group claiming winningTotalPmpe

### DIFF
--- a/packages/ds-sam-calc/package.json
+++ b/packages/ds-sam-calc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-calc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-calc/src/sam.ts
+++ b/packages/ds-sam-calc/src/sam.ts
@@ -80,7 +80,9 @@ type RedelegationAllocation = {
   priorityFrontierPmpe: number | null
   // Standard competition rank by revShare.totalPmpe desc; ties share the higher position.
   rankByVote: Map<string, number>
-  // Lowest-totalPmpe in-set validator; sets winningBidPmpe. null when nobody is in set.
+  // Lowest-totalPmpe validator holding stake at or above the clearing price; sets
+  // winningBidPmpe. The floor keeps backstop stake, which lands in the same
+  // marinadeSamTargetSol field below the cutoff, out of the auction's price.
   marginalWinner: AuctionValidator | null
 }
 
@@ -101,8 +103,8 @@ type RedelegationAllocation = {
 //
 // Memoised per AuctionResult identity: called by computeExpectedStakeChanges,
 // selectRedelegationPriorityFrontierPmpe, selectRedelegationPriorityRank,
-// selectWinningApyForValidator, and computeNextEpochStake — same auction
-// would otherwise run the greedy pass once per consumer per detail open.
+// and computeNextEpochStake — same auction would otherwise run the greedy
+// pass once per consumer per detail open.
 const allocationCache = new WeakMap<AuctionResult, Map<number, RedelegationAllocation>>()
 
 export function allocateRedelegation(auctionResult: AuctionResult, minBondBalanceSol: number): RedelegationAllocation {
@@ -133,7 +135,7 @@ export function allocateRedelegation(auctionResult: AuctionResult, minBondBalanc
       prevPmpe = pmpe
     }
     rankByVote.set(v.voteAccount, groupRank)
-    if (v.auctionStake.marinadeSamTargetSol > 0) {
+    if (v.auctionStake.marinadeSamTargetSol > 0 && pmpe >= auctionResult.winningTotalPmpe) {
       marginalWinner = v
     }
     const belowMin = (v.bondBalanceSol ?? 0) < minBondBalanceSol

--- a/packages/ds-sam-calc/src/sam.ts
+++ b/packages/ds-sam-calc/src/sam.ts
@@ -10,6 +10,11 @@ export const selectPaidUndelegationSol = (v: AuctionValidator): number => v.valu
 export const selectNonBidPmpe = (v: AuctionValidator): number =>
   v.revShare.inflationPmpe + v.revShare.mevPmpe + (v.revShare.blockPmpe ?? 0)
 
+// Tolerance for "sits at the clearing price". Shared by the marginal winner and
+// cutoffRank so the two never disagree about who is at the cutoff when an
+// AuctionResult reaches us with winningTotalPmpe rounded elsewhere.
+const PMPE_EPS = 1e-9
+
 // AugmentedAuctionValidator: AuctionValidator with derived per-validator fields
 // pre-computed. expectedStakeChangeSol drives the next-epoch delta display and
 // decomposes into three signed components that always sum to it:
@@ -135,7 +140,7 @@ export function allocateRedelegation(auctionResult: AuctionResult, minBondBalanc
       prevPmpe = pmpe
     }
     rankByVote.set(v.voteAccount, groupRank)
-    if (v.auctionStake.marinadeSamTargetSol > 0 && pmpe >= auctionResult.winningTotalPmpe) {
+    if (selectInSet(v) && pmpe >= auctionResult.winningTotalPmpe - PMPE_EPS) {
       marginalWinner = v
     }
     const belowMin = (v.bondBalanceSol ?? 0) < minBondBalanceSol
@@ -260,11 +265,10 @@ export function augmentAuctionResult(
   // marginal winner sits at 0. Above-cutoff is +1 (closest tier above), below
   // is -1 (closest tier below). Ranking by totalPmpe (not maxApy) avoids the
   // epochs-per-year wobble — the auction clears on totalPmpe directly.
-  const eps = 1e-9
   const win = auctionResult.winningTotalPmpe
   const pmpes = validators.map(v => v.revShare.totalPmpe)
-  const above = [...new Set(pmpes.filter(p => p > win + eps))].sort((a, b) => a - b)
-  const below = [...new Set(pmpes.filter(p => p < win - eps))].sort((a, b) => b - a)
+  const above = [...new Set(pmpes.filter(p => p > win + PMPE_EPS))].sort((a, b) => a - b)
+  const below = [...new Set(pmpes.filter(p => p < win - PMPE_EPS))].sort((a, b) => b - a)
   const aboveRank = new Map<number, number>()
   above.forEach((p, i) => aboveRank.set(p, 1 + i))
   const belowRank = new Map<number, number>()
@@ -272,7 +276,7 @@ export function augmentAuctionResult(
   const cutoffRanks = new Map<string, number>()
   for (const v of validators) {
     const p = v.revShare.totalPmpe
-    const rank = Math.abs(p - win) < eps ? 0 : p > win ? (aboveRank.get(p) ?? 0) : (belowRank.get(p) ?? 0)
+    const rank = Math.abs(p - win) < PMPE_EPS ? 0 : p > win ? (aboveRank.get(p) ?? 0) : (belowRank.get(p) ?? 0)
     cutoffRanks.set(v.voteAccount, rank)
   }
 

--- a/packages/ds-sam-calc/test/marginal-winner.test.ts
+++ b/packages/ds-sam-calc/test/marginal-winner.test.ts
@@ -1,0 +1,53 @@
+// Tests for allocateRedelegation's marginalWinner: it must name the price-setting
+// auction winner, not any validator that merely holds stake.
+import { allocateRedelegation } from '../src/sam'
+
+import type { AuctionResult, AuctionValidator } from '../src'
+
+function makeValidator(voteAccount: string, totalPmpe: number, samTargetSol: number): AuctionValidator {
+  return {
+    voteAccount,
+    totalActivatedStakeSol: samTargetSol,
+    marinadeActivatedStakeSol: samTargetSol,
+    bondBalanceSol: 100,
+    auctionStake: { marinadeSamTargetSol: samTargetSol },
+    revShare: { totalPmpe },
+    values: { paidUndelegationSol: 0 },
+  } as unknown as AuctionValidator
+}
+
+function makeResult(winningTotalPmpe: number, validators: AuctionValidator[]): AuctionResult {
+  return {
+    winningTotalPmpe,
+    auctionData: {
+      validators,
+      stakeAmounts: { marinadeSamTvlSol: 0, marinadeRemainingSamSol: 0 },
+    },
+  } as unknown as AuctionResult
+}
+
+describe('allocateRedelegation — marginalWinner', () => {
+  it('names the lowest-totalPmpe winner at the clearing price', () => {
+    const result = makeResult(10, [makeValidator('HIGH', 12, 500), makeValidator('MARG', 10, 500)])
+
+    expect(allocateRedelegation(result, 0).marginalWinner?.voteAccount).toBe('MARG')
+  })
+
+  it('ignores stake held below the clearing price', () => {
+    // Backstop stake lands in the same marinadeSamTargetSol field, so a validator
+    // under the cutoff can hold stake without having won the auction.
+    const result = makeResult(10, [
+      makeValidator('HIGH', 12, 500),
+      makeValidator('MARG', 10, 500),
+      makeValidator('BACKSTOP', 4, 500),
+    ])
+
+    expect(allocateRedelegation(result, 0).marginalWinner?.voteAccount).toBe('MARG')
+  })
+
+  it('is null when nobody holds stake at the clearing price', () => {
+    const result = makeResult(10, [makeValidator('OUT', 8, 0), makeValidator('BACKSTOP', 4, 500)])
+
+    expect(allocateRedelegation(result, 0).marginalWinner).toBeNull()
+  })
+})

--- a/packages/ds-sam-sdk/package.json
+++ b/packages/ds-sam-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/ds-sam-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Marinade Finance",
   "license": "ISC",
   "main": "dist/src/index.js",

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -73,10 +73,10 @@ export class Auction {
             `received ${evenDistributionCap} SAM stake in PMPE group ${validator.revShare.totalPmpe} with ${groupValidators.size} validators`,
           )
         }
-        // A fully cap-blocked group distributes nothing, so it must not claim the
-        // clearing price. Consumers derive the marginal winner from
-        // marinadeSamTargetSol > 0, and the two definitions have to agree.
-        if (evenDistributionCap > 0) {
+        // A group that absorbs less than EPSILON has not cleared anything, so it must
+        // not claim the clearing price - otherwise a cap-blocked group, or a crumb of
+        // leftover TVL, drags the price a whole tier below what winners actually paid.
+        if (evenDistributionCap >= EPSILON) {
           winningTotalPmpe = group.totalPmpe
         }
 

--- a/packages/ds-sam-sdk/src/auction.ts
+++ b/packages/ds-sam-sdk/src/auction.ts
@@ -68,11 +68,16 @@ export class Auction {
         for (const validator of groupValidators.values()) {
           validator.auctionStake.marinadeSamTargetSol += evenDistributionCap
           this.data.stakeAmounts.marinadeRemainingSamSol -= evenDistributionCap
-          winningTotalPmpe = validator.revShare.totalPmpe
           this.debug.pushValidatorEvent(
             validator.voteAccount,
             `received ${evenDistributionCap} SAM stake in PMPE group ${validator.revShare.totalPmpe} with ${groupValidators.size} validators`,
           )
+        }
+        // A fully cap-blocked group distributes nothing, so it must not claim the
+        // clearing price. Consumers derive the marginal winner from
+        // marinadeSamTargetSol > 0, and the two definitions have to agree.
+        if (evenDistributionCap > 0) {
+          winningTotalPmpe = group.totalPmpe
         }
 
         this.constraints.updateStateForSam(this.data)
@@ -354,7 +359,9 @@ export class Auction {
     this.debug.pushEvent('STAKE DISTRIBUTED')
 
     if (!isFinite(winningTotalPmpe)) {
-      throw new Error('winningTotalPmpe has to be finite')
+      throw new Error(
+        `winningTotalPmpe has to be finite; no PMPE group absorbed SAM stake, every eligible validator was cap-blocked # ${JSON.stringify(this.data.stakeAmounts)}`,
+      )
     }
 
     if (winningTotalPmpe <= 0) {

--- a/packages/ds-sam-sdk/test/eligibility.test.ts
+++ b/packages/ds-sam-sdk/test/eligibility.test.ts
@@ -112,13 +112,17 @@ describe('eligibility', () => {
       })
 
     const goodVal = new ValidatorMockBuilder(votes.next().value, ids.next().value).withEligibleDefaults()
+    // Network stake outside goodVal's country, otherwise goodVal alone exceeds the
+    // country concentration cap and the auction can distribute nothing at all.
+    const networkBallast = new ValidatorMockBuilder(votes.next().value, ids.next().value).withExternalStake(2_000_000)
 
-    const dsSam = new DsSamSDK({}, defaultStaticDataProviderBuilder([val, goodVal]))
+    const dsSam = new DsSamSDK({}, defaultStaticDataProviderBuilder([val, goodVal, networkBallast]))
     const result = await dsSam.run()
 
     const v = findValidatorInResult(val.voteAccount, result)
     assert(v)
     expect(v.samEligible).toBe(false)
     expect(v.auctionStake.marinadeSamTargetSol).toBe(0)
+    expect(findValidatorInResult(goodVal.voteAccount, result)?.auctionStake.marinadeSamTargetSol).toBeGreaterThan(0)
   })
 })

--- a/packages/ds-sam-sdk/test/marginalWinner.test.ts
+++ b/packages/ds-sam-sdk/test/marginalWinner.test.ts
@@ -1,0 +1,137 @@
+import assert from 'assert'
+
+import { allocateRedelegation, selectNonBidPmpe } from '@marinade.finance/ds-sam-calc'
+
+import { DsSamSDK } from '../src'
+import { defaultStaticDataProviderBuilder } from './helpers/static-data-provider-builder'
+import { ValidatorMockBuilder, generateIdentities, generateVoteAccounts } from './helpers/validator-mock-builder'
+
+import type { AuctionResult, AuctionValidator } from '../src'
+
+// psr-dashboard rebases the clearing price onto a validator's own commission
+// profile as `winningTotalPmpe - selectNonBidPmpe(marginalWinner)`, where
+// marginalWinner is the lowest-PMPE validator holding SAM stake. That is only a
+// bid while winningTotalPmpe names the marginal winner's own PMPE group;
+// otherwise the subtraction crosses two unrelated validators and the caller's
+// Math.max(0, ...) hides the mismatch. Backstop stake also lands in
+// marinadeSamTargetSol, so this only holds while the backstop is disabled.
+const assertMarginalWinnerIsMarginal = (result: AuctionResult): AuctionValidator => {
+  const { marginalWinner } = allocateRedelegation(result, 0)
+  const winners = result.auctionData.validators.filter(v => v.auctionStake.marinadeSamTargetSol > 0)
+
+  expect(winners.length).toBeGreaterThan(0)
+  assert(marginalWinner, 'auction produced no marginal winner')
+
+  const lowestWinnerPmpe = Math.min(...winners.map(v => v.revShare.totalPmpe))
+  expect(marginalWinner.revShare.totalPmpe).toStrictEqual(lowestWinnerPmpe)
+  expect(result.winningTotalPmpe).toStrictEqual(lowestWinnerPmpe)
+  expect(result.winningTotalPmpe - selectNonBidPmpe(marginalWinner)).toBeCloseTo(marginalWinner.revShare.bidPmpe, 9)
+
+  return marginalWinner
+}
+
+// Uniform-price settlement: the marginal winner sets the price, so it pays
+// exactly its own bid, and no winner ever pays more than it bid. Both follow
+// from winningTotalPmpe naming the marginal winner's group — understating it
+// charges every winner below the true clearing price.
+const assertWinnersPayClearingPrice = (result: AuctionResult, marginalWinner: AuctionValidator) => {
+  const winners = result.auctionData.validators.filter(v => v.auctionStake.marinadeSamTargetSol > 0)
+
+  expect(marginalWinner.revShare.auctionEffectiveStaticBidPmpe).toBeCloseTo(marginalWinner.revShare.bidPmpe, 9)
+
+  for (const winner of winners) {
+    const { revShare } = winner
+    expect(revShare.auctionEffectiveStaticBidPmpe).toBeLessThanOrEqual(revShare.bidPmpe + 1e-9)
+    expect(revShare.auctionEffectiveBidPmpe).toBeCloseTo(
+      Math.max(0, result.winningTotalPmpe - revShare.onchainDistributedPmpe),
+      9,
+    )
+  }
+}
+
+// Five winners WANT-capped far below TVL, so SAM stake is still undistributed
+// when the auction descends into the cheapest group; that group holds a single
+// eligible validator whose country already exceeds the network concentration
+// cap, so its cap never leaves 0 and it wins nothing.
+const capBlockedTailScenario = () => {
+  const voteAccounts = generateVoteAccounts()
+  const identities = generateIdentities()
+  const winners = Array.from({ length: 5 }, (_, i) =>
+    new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
+      .withEligibleDefaults()
+      .withCountry('WINNER_COUNTRY')
+      .withAso('WINNER_ASO')
+      .withLiquidStake(200_000)
+      .withExternalStake(10_000)
+      .withBond({ stakeWanted: 1_000, cpmpe: 0.5 + i * 0.1, balance: 1000 }),
+  )
+  const capBlocked = new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
+    .withEligibleDefaults()
+    .withCountry('SATURATED_COUNTRY')
+    .withAso('SATURATED_ASO')
+    .withLiquidStake(0)
+    .withExternalStake(50_000_000)
+    .withBond({ stakeWanted: 1e6, cpmpe: 0.01, balance: 1000 })
+
+  return { validators: [...winners, capBlocked], capBlocked }
+}
+
+describe('marginal winner', () => {
+  it('names the lowest-PMPE winner when every group can absorb stake', async () => {
+    const voteAccounts = generateVoteAccounts()
+    const identities = generateIdentities()
+    const validators = Array.from({ length: 30 }, (_, i) =>
+      new ValidatorMockBuilder(voteAccounts.next().value, identities.next().value)
+        .withEligibleDefaults()
+        .withBond({ stakeWanted: 1e6, cpmpe: 0.1 + i * 0.01, balance: 1000 }),
+    )
+
+    const result = await new DsSamSDK({}, defaultStaticDataProviderBuilder(validators)).run()
+    const marginalWinner = assertMarginalWinnerIsMarginal(result)
+    assertWinnersPayClearingPrice(result, marginalWinner)
+
+    expect(marginalWinner.revShare.bidPmpe).toStrictEqual(0.1)
+  })
+
+  it('names the lowest-PMPE winner when the cheapest group is cap-blocked and stake is left over', async () => {
+    const { validators, capBlocked } = capBlockedTailScenario()
+
+    const result = await new DsSamSDK({}, defaultStaticDataProviderBuilder(validators)).run()
+
+    const blocked = result.auctionData.validators.find(v => v.voteAccount === capBlocked.voteAccount)
+    expect(blocked?.samEligible).toStrictEqual(true)
+    expect(blocked?.auctionStake.marinadeSamTargetSol).toStrictEqual(0)
+    expect(result.auctionData.stakeAmounts.marinadeRemainingSamSol).toBeGreaterThan(0)
+
+    assertMarginalWinnerIsMarginal(result)
+  })
+
+  it('charges the clearing price when the cheapest group is cap-blocked', async () => {
+    const { validators, capBlocked } = capBlockedTailScenario()
+
+    const result = await new DsSamSDK({}, defaultStaticDataProviderBuilder(validators)).run()
+    const marginalWinner = assertMarginalWinnerIsMarginal(result)
+    assertWinnersPayClearingPrice(result, marginalWinner)
+
+    // The cap-blocked validator sits below the cutoff and is billed as an outsider.
+    const blocked = result.auctionData.validators.find(v => v.voteAccount === capBlocked.voteAccount)
+    expect(blocked?.revShare.auctionEffectiveBidPmpe).toStrictEqual(blocked?.revShare.bondObligationPmpe)
+  })
+
+  // expectedMaxWinningBidRatio makes the dry run in updateExpectedMaxEffBidPmpe
+  // feed bond stake caps, so a clearing price taken from a cap-blocked group
+  // would understate every validator's expected bid and inflate its cap.
+  it('keeps the clearing price intact when the dry run drives bond caps', async () => {
+    const { validators } = capBlockedTailScenario()
+
+    const result = await new DsSamSDK(
+      { expectedMaxWinningBidRatio: 1.2, minExpectedEffBidPmpe: 0.01 },
+      defaultStaticDataProviderBuilder(validators),
+    ).run()
+    const marginalWinner = assertMarginalWinnerIsMarginal(result)
+    assertWinnersPayClearingPrice(result, marginalWinner)
+
+    // The dry run priced a real bid rather than collapsing to minExpectedEffBidPmpe.
+    expect(marginalWinner.revShare.expectedMaxEffBidPmpe).toBeGreaterThan(0.01)
+  })
+})

--- a/packages/ds-sam-sdk/test/marginalWinner.test.ts
+++ b/packages/ds-sam-sdk/test/marginalWinner.test.ts
@@ -101,7 +101,9 @@ describe('marginal winner', () => {
     const blocked = result.auctionData.validators.find(v => v.voteAccount === capBlocked.voteAccount)
     expect(blocked?.samEligible).toStrictEqual(true)
     expect(blocked?.auctionStake.marinadeSamTargetSol).toStrictEqual(0)
-    expect(result.auctionData.stakeAmounts.marinadeRemainingSamSol).toBeGreaterThan(0)
+    // Far above EPSILON, or distributeSamStake would stop before descending into the
+    // cap-blocked group and these tests would pass with the fix reverted.
+    expect(result.auctionData.stakeAmounts.marinadeRemainingSamSol).toBeGreaterThan(100_000)
 
     assertMarginalWinnerIsMarginal(result)
   })


### PR DESCRIPTION
Coming from a question at https://marinade-group.slack.com/archives/C0818BVGDV2/p1786516935053819
A follow-up PR in psr dashboard: https://github.com/marinade-finance/psr-dashboard/pull/166

Stop a cap-blocked PMPE group from claiming the auction's clearing price, which underbilled every winner.

- Record `winningTotalPmpe` only from a group that actually absorbed stake, so the clearing price stays derivable from the winner set instead of naming a group that received nothing
- Require a validator to sit at or above the clearing price before it can be the `marginalWinner`, since backstop stake lands in the same `marinadeSamTargetSol` field and would otherwise set the price from below the cutoff
- Name the cause in the non-finite `winningTotalPmpe` error and attach the stake amounts, because the fix makes that throw reachable whenever nothing can be distributed
- Add regression coverage for the leftover-TVL case: the invariant that the clearing price is the lowest winner's, and the uniform-price contract that the marginal winner pays its own bid and no winner pays more
- Give the empty-`epochStats` eligibility fixture network stake outside its own country, which previously left the auction unable to distribute anything at all



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auction clearing-price selection when distribution caps prevent groups from receiving stake.
  * Corrected marginal-winner selection to use eligible validators meeting the clearing price.
  * Improved settlement and billing outcomes for blocked validators and undistributed stake.
  * Added clearer diagnostics when a valid clearing price cannot be calculated.

* **Tests**
  * Expanded coverage for marginal-winner selection, clearing prices, stake allocation, and eligibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->